### PR TITLE
Disconnect by closing pexpect sessions

### DIFF
--- a/tests/util/protocol_util.py
+++ b/tests/util/protocol_util.py
@@ -51,7 +51,7 @@ class ProtocolTester(object):
         self.login()
 
     def disconnect(self):
-        pass
+        self.child.close()
 
     def get_ssh_connect_command(self):
         pass


### PR DESCRIPTION
Prevents "out of pty devices" errors while running the tests.

Traceback:
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/pty.py", line 29, in openpty
    master_fd, slave_name = _open_terminal()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/pty.py", line 70, in _open_terminal
    raise os.error, 'out of pty devices'
OSError: out of pty devices