### PR TITLE
get_interface with non-existing interface.

### DIFF
--- a/fake_switches/brocade/command_processor/enabled.py
+++ b/fake_switches/brocade/command_processor/enabled.py
@@ -139,11 +139,16 @@ class EnabledCommandProcessor(BaseCommandProcessor):
             self.write_line("")
 
     def show_int(self, args):
+        ports = []
         if len(args) > 1:
-            ports = [self.switch_configuration.get_port_by_partial_name(" ".join(args[1:]))]
+            port = self.switch_configuration.get_port_by_partial_name(" ".join(args[1:]))
+            if port:
+                ports.append(port)
         else:
             ports = self.switch_configuration.ports
-
+        if not ports:
+            name, number = split_port_name(" ".join(args[1:]))
+            self.write_line("Error - invalid interface {}".format(number))
         for port in ports:
             if isinstance(port, VlanPort):
                 _, port_id = split_port_name(port.name)

--- a/tests/brocade/test_brocade_switch_protocol.py
+++ b/tests/brocade/test_brocade_switch_protocol.py
@@ -152,6 +152,14 @@ class TestBrocadeSwitchProtocol(unittest.TestCase):
         remove_vlan(t, "123")
 
     @with_protocol
+    def test_command_interface_tagged_with_native_default_vlan(self, t):
+        enable(t)
+
+        t.write("show interface ethe 1/25")
+        t.readln("Error - invalid interface 1/25")
+        t.read("SSH@my_switch#")
+
+    @with_protocol
     def test_remove_a_ports_from_a_vlan_should_print_an_error(self, t):
         enable(t)
 


### PR DESCRIPTION
Ensure that the CLI answers Error - invalid interface 1/25 when calling get_interface on an unexisting interface.
Was crashing before, ports = [None]