### PR TITLE
Add ports support to dell show vlan {id}

### DIFF
--- a/fake_switches/dell/command_processor/enabled.py
+++ b/fake_switches/dell/command_processor/enabled.py
@@ -232,24 +232,14 @@ class DellEnabledCommandProcessor(BaseCommandProcessor):
 
     def _build_port_strings(self, ports):
         port_range_list = group_sequences(ports, are_in_sequence=_are_in_sequence)
-
-        out = []
+        port_list = []
         for port_range in port_range_list:
             first_details = _get_interface_details(port_range[0].name)
             if len(port_range) == 1:
-                out.append("{}{}".format(first_details.port_prefix, first_details.port))
+                port_list.append("{}{}".format(first_details.port_prefix, first_details.port))
             else:
-                out.append("{0}{1}-{0}{2}".format(first_details.port_prefix, first_details.port, _get_interface_details(port_range[-1].name).port))
-        out_str = [""]
-        for str_out in out:
-            new_line_length = len(out_str[-1]) + len(str_out) + 1
-            if len(out_str[-1]) > 1:
-                out_str[-1] += ","
-            if new_line_length <= 13:
-                out_str[-1] += str_out
-            else:
-                out_str.append(str_out)
-        return out_str
+                port_list.append("{0}{1}-{0}{2}".format(first_details.port_prefix, first_details.port, _get_interface_details(port_range[-1].name).port))
+        return _assemble_elements_on_lines(port_list, max_line_char=13)
 
     def continue_vlan_pages(self, lines, _):
         self.write_line("\r                     ")
@@ -336,8 +326,7 @@ def _is_vlan_id(text):
 def _are_in_sequence(a,b):
     details_a = _get_interface_details(a.name)
     details_b = _get_interface_details(b.name)
-    return details_a.port + 1 == details_b.port and details_a.port_prefix == details_b.port_prefix and \
-           details_a.interface == details_b.interface
+    return details_a.port + 1 == details_b.port and details_a.port_prefix == details_b.port_prefix
 
 
 def _get_interface_details(interface_name):
@@ -346,3 +335,16 @@ def _get_interface_details(interface_name):
     interface, slot_descriptor = interface_name.split(" ")
     port_prefix, port = re_port_number.match(slot_descriptor).groups()
     return interface_descriptor(interface, port_prefix, int(port))
+
+
+def _assemble_elements_on_lines(elements, max_line_char, separator=','):
+    lines = [""]
+    for element in elements:
+        if len(lines[-1]) > 1:
+            lines[-1] += separator
+        new_line_length = len(lines[-1]) + len(element)
+        if new_line_length <= max_line_char:
+            lines[-1] += element
+        else:
+            lines.append(element)
+    return lines

--- a/fake_switches/dell/command_processor/enabled.py
+++ b/fake_switches/dell/command_processor/enabled.py
@@ -226,9 +226,7 @@ class DellEnabledCommandProcessor(BaseCommandProcessor):
         ports = []
         for port in self.switch_configuration.ports:
             if not isinstance(port, VlanPort):
-                if (port.trunk_vlans and vlan.number in port.trunk_vlans) \
-                        or port.access_vlan == vlan.number \
-                        or port.trunk_native_vlan == vlan.number:
+                if (port.trunk_vlans and vlan.number in port.trunk_vlans) or port.access_vlan == vlan.number:
                     ports.append(port)
         return ports
 

--- a/tests/dell/test_enabled.py
+++ b/tests/dell/test_enabled.py
@@ -309,8 +309,20 @@ class DellEnabledTest(unittest.TestCase):
         t.readln("")
         t.read("my_switch#")
 
+        configuring_interface(t, "ethernet 1/xg1", do="switchport mode trunk")
+        configuring_a_vlan_on_interface(t, "ethernet 1/xg1", do="switchport trunk allowed vlan add 1000")
+        t.write("show vlan id 1000")
+        t.readln("")
+        t.readln("VLAN       Name                         Ports          Type      Authorization")
+        t.readln("-----  ---------------                  -------------  -----     -------------")
+        t.readln("1000                                    1/g1-1/g2,     Static    Required     ")
+        t.readln("                                        1/xg1                                 ")
+        t.readln("")
+        t.read("my_switch#")
+
         configuring_interface(t, "ethernet 1/g1", do="switchport mode access")
         configuring_interface(t, "ethernet 1/g2", do="switchport mode access")
+        configuring_interface(t, "ethernet 1/xg1", do="switchport mode access")
 
         unconfigure_vlan(t, 1000)
 


### PR DESCRIPTION
Supports vlan with multiple line for ports.
Supports interface using more than one letter (2/xg1).
Supports sequenced interface 1/g1-1/g2