### PR TITLE
Removed the overridable member from the juniper test

### DIFF
--- a/tests/juniper/juniper_base_protocol_test.py
+++ b/tests/juniper/juniper_base_protocol_test.py
@@ -27,8 +27,6 @@ class JuniperBaseProtocolTest(unittest.TestCase):
     def setUp(self):
         self.nc = self.create_client()
 
-        self.PORT_MODE_TAG = "port-mode"
-
     def tearDown(self):
         try:
             self.nc.discard_changes()
@@ -270,7 +268,7 @@ class JuniperBaseProtocolTest(unittest.TestCase):
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "access",
+                                "port-mode": "access",
                                 "vlan": [
                                     {"members": "2995"},
                                 ]}}}]}]}})
@@ -286,12 +284,12 @@ class JuniperBaseProtocolTest(unittest.TestCase):
 
         assert_that(int003.xpath("name")[0].text, equal_to("ge-0/0/3"))
         assert_that(int003.xpath("unit/family/ethernet-switching/*"), has_length(2))
-        assert_that(int003.xpath("unit/family/ethernet-switching/{}".format(self.PORT_MODE_TAG))[0].text,
+        assert_that(int003.xpath("unit/family/ethernet-switching/port-mode")[0].text,
                     equal_to("access"))
         assert_that(int003.xpath("unit/family/ethernet-switching/vlan/members"), has_length(1))
         assert_that(int003.xpath("unit/family/ethernet-switching/vlan/members")[0].text, equal_to("2995"))
 
-        self.cleanup(vlan("VLAN2995"), interface("ge-0/0/3", [self.PORT_MODE_TAG, "vlan"]))
+        self.cleanup(vlan("VLAN2995"), interface("ge-0/0/3", ["port-mode", "vlan"]))
 
     def test_assigning_unknown_vlan_raises(self):
         self.edit({
@@ -320,7 +318,7 @@ class JuniperBaseProtocolTest(unittest.TestCase):
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "trunk",
+                                "port-mode": "trunk",
                                 "vlan": {"members": "2995-2996"}}}}]}]}})
 
         with self.assertRaises(RPCError):
@@ -361,12 +359,12 @@ class JuniperBaseProtocolTest(unittest.TestCase):
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "trunk"
+                                "port-mode": "trunk"
                                 }}}]}]}})
         self.nc.commit()
 
         self.cleanup(vlan("VLAN2995"), vlan("VLAN2996"), vlan("VLAN2997"),
-                     interface("ge-0/0/3", [self.PORT_MODE_TAG]))
+                     interface("ge-0/0/3", ["port-mode"]))
         result = self.nc.get_config(source="running", filter=dict_2_etree({"filter": {
             "configuration": {"vlans": {}}}
         }))
@@ -392,7 +390,7 @@ class JuniperBaseProtocolTest(unittest.TestCase):
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "trunk",
+                                "port-mode": "trunk",
                                 "native-vlan-id": "2996",
                                 "vlan": [
                                     {"members": "2995"},
@@ -410,7 +408,7 @@ class JuniperBaseProtocolTest(unittest.TestCase):
 
         assert_that(int003.xpath("name")[0].text, equal_to("ge-0/0/3"))
         assert_that(int003.xpath("unit/family/ethernet-switching/*"), has_length(3))
-        assert_that(int003.xpath("unit/family/ethernet-switching/{}".format(self.PORT_MODE_TAG))[0].text,
+        assert_that(int003.xpath("unit/family/ethernet-switching/port-mode")[0].text,
                     equal_to("trunk"))
         assert_that(int003.xpath("unit/family/ethernet-switching/native-vlan-id")[0].text, equal_to("2996"))
         assert_that(int003.xpath("unit/family/ethernet-switching/vlan/members"), has_length(2))
@@ -450,7 +448,7 @@ class JuniperBaseProtocolTest(unittest.TestCase):
         self.nc.commit()
 
         self.cleanup(vlan("VLAN2995"), vlan("VLAN2996"), vlan("VLAN2997"),
-                     interface("ge-0/0/3", [self.PORT_MODE_TAG, "native-vlan-id", "vlan"]))
+                     interface("ge-0/0/3", ["port-mode", "native-vlan-id", "vlan"]))
         result = self.nc.get_config(source="running", filter=dict_2_etree({"filter": {
             "configuration": {"vlans": {}}}
         }))
@@ -476,7 +474,7 @@ class JuniperBaseProtocolTest(unittest.TestCase):
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "trunk",
+                                "port-mode": "trunk",
                                 "native-vlan-id": "2995",
                                 "vlan": [
                                     {"members": "2997"},
@@ -491,7 +489,7 @@ class JuniperBaseProtocolTest(unittest.TestCase):
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "trunk",
+                                "port-mode": "trunk",
                                 "native-vlan-id": "2996",
                                 "vlan": [
                                     {"members": "2997"},
@@ -508,7 +506,7 @@ class JuniperBaseProtocolTest(unittest.TestCase):
         assert_that(int003.xpath("unit/family/ethernet-switching/native-vlan-id")[0].text, equal_to("2996"))
 
         self.cleanup(vlan("VLAN2995"), vlan("VLAN2996"), vlan("VLAN2997"),
-                     interface("ge-0/0/3", [self.PORT_MODE_TAG, "vlan", "native-vlan-id"]))
+                     interface("ge-0/0/3", ["port-mode", "vlan", "native-vlan-id"]))
         result = self.nc.get_config(source="running", filter=dict_2_etree({"filter": {
             "configuration": {"vlans": {}}}
         }))
@@ -534,7 +532,7 @@ class JuniperBaseProtocolTest(unittest.TestCase):
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "trunk"
+                                "port-mode": "trunk"
                             }}}]}]}})
         self.nc.commit()
 
@@ -573,7 +571,7 @@ class JuniperBaseProtocolTest(unittest.TestCase):
         assert_that(int003.xpath("unit/family/ethernet-switching/native-vlan-id")[0].text, equal_to("2995"))
 
         self.cleanup(vlan("VLAN2995"), vlan("VLAN2996"), vlan("VLAN2997"),
-                     interface("ge-0/0/3", [self.PORT_MODE_TAG, "vlan", "native-vlan-id"]))
+                     interface("ge-0/0/3", ["port-mode", "vlan", "native-vlan-id"]))
         result = self.nc.get_config(source="running", filter=dict_2_etree({"filter": {
             "configuration": {"vlans": {}}}
         }))
@@ -606,7 +604,7 @@ class JuniperBaseProtocolTest(unittest.TestCase):
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "trunk"
+                                "port-mode": "trunk"
                             }}}]}]}})
         self.nc.commit()
 
@@ -656,7 +654,7 @@ class JuniperBaseProtocolTest(unittest.TestCase):
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "access"
+                                "port-mode": "access"
                             }}}]}]}})
         self.nc.commit()
 
@@ -670,7 +668,7 @@ class JuniperBaseProtocolTest(unittest.TestCase):
         assert_that(int003.xpath("unit/family/ethernet-switching/vlan/members"), has_length(0))
 
         self.cleanup(vlan("VLAN1100"), vlan("VLAN1200"), vlan("VLAN1300"), vlan("VLAN1400"),
-                     interface("ge-0/0/3", [self.PORT_MODE_TAG, "vlan", "native-vlan-id"]))
+                     interface("ge-0/0/3", ["port-mode", "vlan", "native-vlan-id"]))
         result = self.nc.get_config(source="running", filter=dict_2_etree({"filter": {
             "configuration": {"vlans": {}}}
         }))
@@ -697,7 +695,7 @@ class JuniperBaseProtocolTest(unittest.TestCase):
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "trunk",
+                                "port-mode": "trunk",
                                 "native-vlan-id": "2996",
                                 "vlan": [
                                     {"members": "2995"},
@@ -723,7 +721,7 @@ class JuniperBaseProtocolTest(unittest.TestCase):
         assert_that(int003.xpath("unit/family/ethernet-switching/native-vlan-id")[0].text, equal_to("2996"))
 
         self.cleanup(vlan("VLAN2995"), vlan("VLAN2996"), vlan("VLAN2997"),
-                     interface("ge-0/0/3", [self.PORT_MODE_TAG, "vlan", "native-vlan-id"]))
+                     interface("ge-0/0/3", ["port-mode", "vlan", "native-vlan-id"]))
         result = self.nc.get_config(source="running", filter=dict_2_etree({"filter": {
             "configuration": {"vlans": {}}}
         }))
@@ -1000,7 +998,7 @@ class JuniperBaseProtocolTest(unittest.TestCase):
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "trunk",
+                                "port-mode": "trunk",
                                 "vlan": [
                                     {"members": "2995"},
                                     {"members": "2997"}]}}}]}]}})
@@ -1033,14 +1031,14 @@ class JuniperBaseProtocolTest(unittest.TestCase):
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "access"}}}]}]},
+                                "port-mode": "access"}}}]}]},
                 {"interface": [
                     {"name": "ge-0/0/2"},
                     {"unit": [
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "access"}}}]}]},
+                                "port-mode": "access"}}}]}]},
             ]})
         self.nc.commit()
 
@@ -1062,7 +1060,7 @@ class JuniperBaseProtocolTest(unittest.TestCase):
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "trunk",
+                                "port-mode": "trunk",
                                 "vlan": [
                                     {"members": "2995"}]}}}]}]},
                 {"interface": [

--- a/tests/juniper/juniper_base_protocol_with_commit_delay_test.py
+++ b/tests/juniper/juniper_base_protocol_with_commit_delay_test.py
@@ -27,8 +27,6 @@ class JuniperBaseProtocolWithCommitDelayTest(unittest.TestCase):
     def setUp(self):
         self.nc = self.create_client()
 
-        self.PORT_MODE_TAG = "port-mode"
-
     def tearDown(self):
         try:
             self.nc.discard_changes()

--- a/tests/juniper_qfx_copper/juniper_qfx_copper_protocol_test.py
+++ b/tests/juniper_qfx_copper/juniper_qfx_copper_protocol_test.py
@@ -31,8 +31,6 @@ class JuniperQfxCopperProtocolTest(unittest.TestCase):
     def setUp(self):
         self.nc = self.create_client()
 
-        self.PORT_MODE_TAG = "interface-mode"
-
     def tearDown(self):
         try:
             self.nc.discard_changes()
@@ -274,7 +272,7 @@ class JuniperQfxCopperProtocolTest(unittest.TestCase):
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "access",
+                                "interface-mode": "access",
                                 "vlan": [
                                     {"members": "2995"},
                                 ]}}}]}]}})
@@ -290,12 +288,12 @@ class JuniperQfxCopperProtocolTest(unittest.TestCase):
 
         assert_that(int003.xpath("name")[0].text, equal_to("ge-0/0/3"))
         assert_that(int003.xpath("unit/family/ethernet-switching/*"), has_length(2))
-        assert_that(int003.xpath("unit/family/ethernet-switching/{}".format(self.PORT_MODE_TAG))[0].text,
+        assert_that(int003.xpath("unit/family/ethernet-switching/")[0].text,
                     equal_to("access"))
         assert_that(int003.xpath("unit/family/ethernet-switching/vlan/members"), has_length(1))
         assert_that(int003.xpath("unit/family/ethernet-switching/vlan/members")[0].text, equal_to("2995"))
 
-        self.cleanup(vlan("VLAN2995"), interface("ge-0/0/3", [self.PORT_MODE_TAG, "vlan"]))
+        self.cleanup(vlan("VLAN2995"), interface("ge-0/0/3", ["interface-mode", "vlan"]))
 
     def test_assigning_unknown_vlan_in_a_range_raises(self):
         self.edit({
@@ -310,7 +308,7 @@ class JuniperQfxCopperProtocolTest(unittest.TestCase):
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "trunk",
+                                "interface-mode": "trunk",
                                 "vlan": {"members": "2995-2996"}}}}]}]}})
 
         with self.assertRaises(RPCError):
@@ -351,7 +349,7 @@ class JuniperQfxCopperProtocolTest(unittest.TestCase):
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "trunk"
+                                "interface-mode": "trunk"
                                 }}}]}]}})
         with self.assertRaises(RPCError) as context:
             self.nc.commit()
@@ -383,7 +381,7 @@ configuration check-out failed
 </commit-results>"""))
 
         self.cleanup(vlan("VLAN2995"), vlan("VLAN2996"), vlan("VLAN2997"),
-                         interface("ge-0/0/3", [self.PORT_MODE_TAG]))
+                         interface("ge-0/0/3", ["interface-mode"]))
         result = self.nc.get_config(source="running", filter=dict_2_etree({"filter": {
             "configuration": {"vlans": {}}}
         }))
@@ -410,7 +408,7 @@ configuration check-out failed
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "trunk",
+                                "interface-mode": "trunk",
                                 "vlan": [
                                     {"members": "2995"},
                                     {"members": "2997"},
@@ -428,7 +426,7 @@ configuration check-out failed
         assert_that(int003.xpath("name")[0].text, equal_to("ge-0/0/3"))
         assert_that(int003.xpath("native-vlan-id")[0].text, equal_to("2996"))
         assert_that(int003.xpath("unit/family/ethernet-switching/*"), has_length(2))
-        assert_that(int003.xpath("unit/family/ethernet-switching/{}".format(self.PORT_MODE_TAG))[0].text,
+        assert_that(int003.xpath("unit/family/ethernet-switching/interface-mode")[0].text,
                     equal_to("trunk"))
         assert_that(int003.xpath("unit/family/ethernet-switching/vlan/members"), has_length(2))
         assert_that(int003.xpath("unit/family/ethernet-switching/vlan/members")[0].text, equal_to("2995"))
@@ -454,7 +452,7 @@ configuration check-out failed
         assert_that(int003.xpath("unit/family/ethernet-switching/vlan/members")[0].text, equal_to("2997"))
 
         self.cleanup(vlan("VLAN2995"), vlan("VLAN2996"), vlan("VLAN2997"),
-                     interface("ge-0/0/3", [self.PORT_MODE_TAG, "vlan"]))
+                     interface("ge-0/0/3", ["interface-mode", "vlan"]))
         result = self.nc.get_config(source="running", filter=dict_2_etree({"filter": {
             "configuration": {"vlans": {}}}
         }))
@@ -481,7 +479,7 @@ configuration check-out failed
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "trunk",
+                                "interface-mode": "trunk",
                                 "vlan": [
                                     {"members": "2997"},
                                 ]}}}]}]}})
@@ -505,7 +503,7 @@ configuration check-out failed
         assert_that(int003.xpath("native-vlan-id")[0].text, equal_to("2996"))
 
         self.cleanup(vlan("VLAN2995"), vlan("VLAN2996"), vlan("VLAN2997"),
-                     interface("ge-0/0/3", [self.PORT_MODE_TAG, "vlan"]))
+                     interface("ge-0/0/3", ["interface-mode", "vlan"]))
         result = self.nc.get_config(source="running", filter=dict_2_etree({"filter": {
             "configuration": {"vlans": {}}}
         }))
@@ -531,7 +529,7 @@ configuration check-out failed
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "trunk",
+                                "interface-mode": "trunk",
                                 "vlan": [
                                     {"members": "2996"}
                                 ]
@@ -572,7 +570,7 @@ configuration check-out failed
         assert_that(int003.xpath("unit/family/ethernet-switching/vlan/members")[1].text, equal_to("2997"))
 
         self.cleanup(vlan("VLAN2995"), vlan("VLAN2996"), vlan("VLAN2997"),
-                     interface("ge-0/0/3", [self.PORT_MODE_TAG, "vlan"]))
+                     interface("ge-0/0/3", ["interface-mode", "vlan"]))
         result = self.nc.get_config(source="running", filter=dict_2_etree({"filter": {
             "configuration": {"vlans": {}}}
         }))
@@ -606,7 +604,7 @@ configuration check-out failed
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "trunk",
+                                "interface-mode": "trunk",
                                 "vlan": [
                                     {"members": "1100"},
                                     {"members": "1300"},
@@ -633,7 +631,7 @@ configuration check-out failed
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "access"
+                                "interface-mode": "access"
                             }}}]}]}})
         self.nc.commit()
 
@@ -647,7 +645,7 @@ configuration check-out failed
         assert_that(int003.xpath("unit/family/ethernet-switching/vlan/members"), has_length(0))
 
         self.cleanup(vlan("VLAN1100"), vlan("VLAN1200"), vlan("VLAN1300"), vlan("VLAN1400"),
-                     interface("ge-0/0/3", [self.PORT_MODE_TAG, "vlan"]))
+                     interface("ge-0/0/3", ["interface-mode", "vlan"]))
         result = self.nc.get_config(source="running", filter=dict_2_etree({"filter": {
             "configuration": {"vlans": {}}}
         }))
@@ -675,7 +673,7 @@ configuration check-out failed
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "trunk",
+                                "interface-mode": "trunk",
                                 "vlan": [
                                     {"members": "2995"},
                                     {"members": "2997"},
@@ -700,7 +698,7 @@ configuration check-out failed
         assert_that(members[1].text, equal_to("2997"))
 
         self.cleanup(vlan("VLAN2995"), vlan("VLAN2996"), vlan("VLAN2997"),
-                     interface("ge-0/0/3", [self.PORT_MODE_TAG, "vlan"]))
+                     interface("ge-0/0/3", ["interface-mode", "vlan"]))
         result = self.nc.get_config(source="running", filter=dict_2_etree({"filter": {
             "configuration": {"vlans": {}}}
         }))
@@ -1027,7 +1025,7 @@ configuration check-out failed
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "trunk",
+                                "interface-mode": "trunk",
                                 "vlan": [
                                     {"members": "2995"},
                                     {"members": "2997"}]}}}]}]}})
@@ -1060,14 +1058,14 @@ configuration check-out failed
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "access"}}}]}]},
+                                "interface-mode": "access"}}}]}]},
                 {"interface": [
                     {"name": "ge-0/0/2"},
                     {"unit": [
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "access"}}}]}]},
+                                "interface-mode": "access"}}}]}]},
             ]})
         self.nc.commit()
 
@@ -1089,7 +1087,7 @@ configuration check-out failed
                         {"name": "0"},
                         {"family": {
                             "ethernet-switching": {
-                                self.PORT_MODE_TAG: "trunk",
+                                "interface-mode": "trunk",
                                 "vlan": [
                                     {"members": "2995"}]}}}]}]},
                 {"interface": [

--- a/tests/juniper_qfx_copper/juniper_qfx_copper_protocol_test.py
+++ b/tests/juniper_qfx_copper/juniper_qfx_copper_protocol_test.py
@@ -288,7 +288,7 @@ class JuniperQfxCopperProtocolTest(unittest.TestCase):
 
         assert_that(int003.xpath("name")[0].text, equal_to("ge-0/0/3"))
         assert_that(int003.xpath("unit/family/ethernet-switching/*"), has_length(2))
-        assert_that(int003.xpath("unit/family/ethernet-switching/")[0].text,
+        assert_that(int003.xpath("unit/family/ethernet-switching/interface-mode")[0].text,
                     equal_to("access"))
         assert_that(int003.xpath("unit/family/ethernet-switching/vlan/members"), has_length(1))
         assert_that(int003.xpath("unit/family/ethernet-switching/vlan/members")[0].text, equal_to("2995"))


### PR DESCRIPTION
This was used when one test would inherit from the other, now that it doesn't no need to have this capability