### PR TITLE
Add aggregated interface on fake-switches should react as the switch does

### DIFF
--- a/fake_switches/juniper_qfx_copper/juniper_qfx_copper_netconf_datastore.py
+++ b/fake_switches/juniper_qfx_copper/juniper_qfx_copper_netconf_datastore.py
@@ -21,6 +21,7 @@ class JuniperQfxCopperNetconfDatastore(JuniperNetconfDatastore):
         super(JuniperQfxCopperNetconfDatastore, self).__init__(configuration)
 
         self.PORT_MODE_TAG = "interface-mode"
+        self.MAX_AGGREGATED_ETHERNET_INTERFACES = 999
 
     def apply_trunk_native_vlan(self, interface_data, port):
         if port.trunk_native_vlan is not None:

--- a/fake_switches/netconf/__init__.py
+++ b/fake_switches/netconf/__init__.py
@@ -126,8 +126,8 @@ class UnknownVlan(NetconfError):
 
 
 class AggregatePortOutOfRange(NetconfError):
-    def __init__(self, port, interface):
-        super(AggregatePortOutOfRange, self).__init__("Port value outside range 1..999 for '{}' in '{}'".format(port, interface))
+    def __init__(self, port, interface, max_range=999):
+        super(AggregatePortOutOfRange, self).__init__("device value outside range 0..{} for '{}' in '{}'".format(max_range, port, interface))
 
 
 class PhysicalPortOutOfRange(NetconfError):

--- a/tests/juniper/juniper_base_protocol_test.py
+++ b/tests/juniper/juniper_base_protocol_test.py
@@ -956,8 +956,7 @@ class JuniperBaseProtocolTest(unittest.TestCase):
                     "interface": [
                         {"name": "ae34345"}
                     ]}})
-        assert_that(str(exc.exception), contains_string("Port value outside range 1..999 for '34345' in 'ae34345'"))
-
+        assert_that(str(exc.exception), contains_string("device value outside range 0..127 for '34345' in 'ae34345'"))
 
     def test_set_interface_disabling(self):
         result = self.nc.get_config(source="running", filter=dict_2_etree({"filter": {

--- a/tests/juniper_qfx_copper/juniper_qfx_copper_protocol_test.py
+++ b/tests/juniper_qfx_copper/juniper_qfx_copper_protocol_test.py
@@ -16,7 +16,7 @@ import unittest
 from lxml import etree
 
 from fake_switches.netconf import dict_2_etree, XML_TEXT, XML_ATTRIBUTES
-from hamcrest import assert_that, has_length, equal_to, has_items, is_, is_not
+from hamcrest import assert_that, has_length, equal_to, has_items, is_, is_not, contains_string
 from ncclient import manager
 from ncclient.operations import RPCError
 from tests import contains_regex
@@ -968,6 +968,15 @@ configuration check-out failed
         int002 = result.xpath("data/configuration/interfaces/interface")[0]
 
         assert_that(int002.xpath("native-vlan-id"), has_length(0))
+
+    def test_set_interface_raises_on_aggregated_out_of_range_port(self):
+        with self.assertRaises(RPCError) as exc:
+            self.edit({
+                "interfaces": {
+                    "interface": [
+                        {"name": "ae9000"}
+                    ]}})
+        assert_that(str(exc.exception), contains_string("device value outside range 0..999 for '9000' in 'ae9000'"))
 
     def test_create_aggregated_port(self):
         self.edit({


### PR DESCRIPTION
both qfx and ex raises device value outside instead of Port value outside.
The ranges also varies according to the switch. Both range starts at 0.