### PR TITLE
Changed the way we simulate empty interfaces in juniper

### DIFF
--- a/fake_switches/juniper/juniper_netconf_datastore.py
+++ b/fake_switches/juniper/juniper_netconf_datastore.py
@@ -124,9 +124,7 @@ class JuniperNetconfDatastore(object):
         self.configurations[target].locked = False
 
     def interface_to_etree(self, port):
-        interface_data = [
-            {"name": port.name}
-        ]
+        interface_data = []
 
         if port.description is not None:
             interface_data.append({"description": port.description})
@@ -188,6 +186,9 @@ class JuniperNetconfDatastore(object):
                 }})
 
             self.apply_trunk_native_vlan(interface_data, port)
+
+        if len(interface_data) > 0:
+            interface_data.insert(0, {"name": port.name})
 
         return interface_data
 

--- a/tests/juniper/__init__.py
+++ b/tests/juniper/__init__.py
@@ -1,0 +1,46 @@
+import unittest
+
+from fake_switches.netconf import dict_2_etree, XML_ATTRIBUTES
+from hamcrest import assert_that, has_length
+
+
+class BaseJuniper(unittest.TestCase):
+
+    def setUp(self):
+        self.nc = self.create_client()
+
+    def tearDown(self):
+        try:
+            self.nc.discard_changes()
+        finally:
+            self.nc.close_session()
+
+    def edit(self, config):
+        result = self.nc.edit_config(target="candidate", config=dict_2_etree({
+            "config": {
+                "configuration": config
+            }
+        }))
+        assert_that(result.xpath("//rpc-reply/ok"), has_length(1))
+
+    def cleanup(self, *args):
+        for clean_it in args:
+            clean_it(self.edit)
+        self.nc.commit()
+
+    def get_interface(self, name):
+        result = self.nc.get_config(source="running", filter=dict_2_etree({"filter": {
+            "configuration": {"interfaces": {"interface": {"name": name}}}}}))
+        if len(result.xpath("data/configuration")) == 0:
+            return None
+        return result.xpath("data/configuration/interfaces/interface")[0]
+
+
+def vlan(vlan_name):
+    def m(edit):
+        edit({"vlans": {
+            "vlan": {"name": vlan_name, XML_ATTRIBUTES: {"operation": "delete"}}
+        }})
+
+    return m
+


### PR DESCRIPTION
Empty interfaces in juniper are not shown through the interface.
Fake-switch now replicate this behaviour.