### PR TITLE
Improve PKG-INFO for pypi description

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,9 @@ url = https://github.com/internaphosting/fake-switches
 author = Internap Hosting
 author-email = opensource@internap.com
 summary = A pluggable switch/router command-line simulator
+description-file = README.md
+license = Apache Software License
+home-page = https://github.com/internap/fake-switches
 classifier =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers


### PR DESCRIPTION
This will add the README, the license and the url in the PKGINFO,
this way, Pypi will be able to get the description of our project.