### PR TITLE
Added a test case and support for another type of invalid port

### DIFF
--- a/fake_switches/brocade/command_processor/__init__.py
+++ b/fake_switches/brocade/command_processor/__init__.py
@@ -2,13 +2,18 @@ from fake_switches.switch_configuration import split_port_name
 
 
 def explain_missing_port(port_name):
-    _, number = split_port_name(port_name)
-    slot, port = number.split('/', 1)
-    if int(port) > 64:
-        return ['Invalid input -> {}'.format(number),
-                'Type ? for a list']
-    else:
-        if int(slot) > 1:
-            return ['Error - interface {} is not an ETHERNET interface'.format(number)]
+    name, number = split_port_name(port_name)
+    try:
+        slot, port = number.split('/', 1)
+
+        if int(port) > 64:
+            return ['Invalid input -> {}'.format(number),
+                    'Type ? for a list']
         else:
-            return ["Error - invalid interface {}".format(number)]
+            if int(slot) > 1:
+                return ['Error - interface {} is not an ETHERNET interface'.format(number)]
+            else:
+                return ["Error - invalid interface {}".format(number)]
+    except ValueError:
+        return ['Invalid input -> {0}  {1}'.format(name.replace('ethe ', ''), number),
+                'Type ? for a list']

--- a/tests/brocade/test_brocade_switch_protocol.py
+++ b/tests/brocade/test_brocade_switch_protocol.py
@@ -232,6 +232,11 @@ class TestBrocadeSwitchProtocol(unittest.TestCase):
         t.readln("Type ? for a list")
         t.read("SSH@my_switch(config)#")
 
+        t.write("interface ethe nonexistent99")
+        t.readln("Invalid input -> nonexistent  99")
+        t.readln("Type ? for a list")
+        t.read("SSH@my_switch(config)#")
+
         t.write("interface ethe 2/1")
         t.readln("Error - interface 2/1 is not an ETHERNET interface")
         t.read("SSH@my_switch(config)#")


### PR DESCRIPTION
Brocade switches validates port properly in most cases. It would not
behave properly if the port was incorrectly named something99
(missing slash in port info)