### PR TITLE
Stop returning empty configurations parts

### DIFF
--- a/tests/juniper/__init__.py
+++ b/tests/juniper/__init__.py
@@ -10,6 +10,7 @@ class BaseJuniper(unittest.TestCase):
         self.nc = self.create_client()
 
     def tearDown(self):
+        assert_that(self.nc.get_config(source="running").xpath("data/configuration/*"), has_length(0))
         try:
             self.nc.discard_changes()
         finally:


### PR DESCRIPTION
To be more consistent with the switch, when nothing is returned
the configuration tag should be empty instead of having empty
interfaces, vlans and protocols.

To ensure the base no-configuration test always work, a tear down
check that all configuration has been reset has been added

This raised an issue with the LLDP not cleared properly and has
been addressed

Fixes #65