### PR TITLE
Add default AE ports to juniper

### DIFF
--- a/fake_switches/juniper/juniper_core.py
+++ b/fake_switches/juniper/juniper_core.py
@@ -25,8 +25,13 @@ from fake_switches.netconf.netconf_protocol import NetconfProtocol
 
 
 class JuniperSwitchCore(object):
-    def __init__(self, switch_configuration, datastore_class=JuniperNetconfDatastore):
+    def __init__(self, switch_configuration, datastore_class=JuniperNetconfDatastore, aggregated_port_count=24):
         self.switch_configuration = switch_configuration
+
+        # the aggregated port are considered physical ports and are always existing in a junos environment
+        for i in range(0, aggregated_port_count):
+            switch_configuration.add_port(switch_configuration.new("AggregatedPort", name="ae{}".format(i)))
+
         self.last_connection_id = 0
         self.datastore = datastore_class(self.switch_configuration)
 

--- a/fake_switches/juniper_qfx_copper/juniper_qfx_copper_core.py
+++ b/fake_switches/juniper_qfx_copper/juniper_qfx_copper_core.py
@@ -17,7 +17,8 @@ from fake_switches.juniper_qfx_copper.juniper_qfx_copper_netconf_datastore impor
 
 
 class JuniperQfxCopperSwitchCore(JuniperSwitchCore):
-    def __init__(self, switch_configuration):
+    def __init__(self, switch_configuration, aggregated_port_count=24):
         super(JuniperQfxCopperSwitchCore, self).__init__(
             switch_configuration,
-            datastore_class=JuniperQfxCopperNetconfDatastore)
+            datastore_class=JuniperQfxCopperNetconfDatastore,
+            aggregated_port_count=aggregated_port_count)

--- a/fake_switches/switch_configuration.py
+++ b/fake_switches/switch_configuration.py
@@ -234,11 +234,11 @@ class VlanPort(Port):
 
 
 class AggregatedPort(Port):
-    def __init__(self, *args, **kwargs):
-        super(AggregatedPort, self).__init__(*args, **kwargs)
-
+    def reset(self):
         self.lacp_active = False
         self.lacp_periodic = None
+
+        super(AggregatedPort, self).reset()
 
     def get_child_ports_linked_to_a_machine(self):
         return [p for p in self.switch_configuration.ports if p.aggregation_membership == self.name and p.link_name is not None]

--- a/tests/util/global_reactor.py
+++ b/tests/util/global_reactor.py
@@ -99,7 +99,7 @@ class ThreadedReactor(threading.Thread):
             Port("ge-0/0/2"),
             Port("ge-0/0/3"),
             Port("ge-0/0/4")
-        ]))
+        ]), aggregated_port_count=4)
         SwitchSshService(juniper_switch_ip, ssh_port=juniper_switch_netconf_port, switch_core=switch_core,
                          users={'root': 'root'}).hook_to_reactor(cls._threaded_reactor.reactor)
 
@@ -109,7 +109,7 @@ class ThreadedReactor(threading.Thread):
                 Port("ge-0/0/2"),
                 Port("ge-0/0/3"),
                 Port("ge-0/0/4")
-            ]))
+            ]), aggregated_port_count=4)
         SwitchSshService(juniper_qfx_copper_switch_ip, ssh_port=juniper_qfx_copper_switch_netconf_port,
                          switch_core=switch_core, users={'root': 'root'}).hook_to_reactor(cls._threaded_reactor.reactor)
 


### PR DESCRIPTION
The problem rose when trying to get rid of the rstp protocols
xml node without an existing interface, the interface will now
always exist as they should always have to mimic the real
juniper.

You can assert this behavior by the get-interface-information terse
and see all the aggregated ports in there