### PR TITLE
Use latest tagged ncclient

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,4 +3,4 @@ mock>=1.0.1
 pyhamcrest>=1.6
 pexpect>=3.3
 flexmock>=0.9.7
--e git+https://github.com/leopoul/ncclient.git@master#egg=ncclient
+ncclient>=0.5.0


### PR DESCRIPTION
This will ensure that we use a tagged version and not the current master
that might be broken.