### PR TITLE
Support full auto-negotiation flags

### DIFF
--- a/fake_switches/netconf/__init__.py
+++ b/fake_switches/netconf/__init__.py
@@ -46,8 +46,8 @@ class SimpleDatastore(object):
         pass
 
 class Response(object):
-    def __init__(self, etree_object, require_disconnect=False):
-        self.etree = etree_object
+    def __init__(self, elements, require_disconnect=False):
+        self.elements = elements if isinstance(elements, list) else [elements]
         self.require_disconnect = require_disconnect
 
 
@@ -108,6 +108,11 @@ class NetconfError(Exception):
         self.tag = tag
         self.info = info
         self.path = path
+
+
+class MultipleNetconfErrors(Exception):
+    def __init__(self, errors):
+        self.errors = errors
 
 
 class AlreadyLocked(NetconfError):

--- a/tests/juniper_qfx_copper/juniper_qfx_copper_protocol_test.py
+++ b/tests/juniper_qfx_copper/juniper_qfx_copper_protocol_test.py
@@ -993,7 +993,6 @@ configuration check-out failed
                     {"description": {XML_ATTRIBUTES: {"operation": "delete"}}},
                     {"aggregated-ether-options": {
                         "link-speed": "10g",
-                        "auto-negotiation": {},
                         "lacp": {
                             "active": {},
                             "periodic": "slow"}}}]}})
@@ -1001,9 +1000,8 @@ configuration check-out failed
 
         ae1 = self.get_interface("ae1")
         assert_that(ae1.xpath("*"), has_length(2))
-        assert_that(ae1.xpath("aggregated-ether-options/*"), has_length(3))
+        assert_that(ae1.xpath("aggregated-ether-options/*"), has_length(2))
         assert_that(ae1.xpath("aggregated-ether-options/link-speed")[0].text, is_("10g"))
-        assert_that(ae1.xpath("aggregated-ether-options/auto-negotiation"), has_length(1))
         assert_that(ae1.xpath("aggregated-ether-options/lacp/*"), has_length(2))
         assert_that(ae1.xpath("aggregated-ether-options/lacp/active"), has_length(1))
         assert_that(ae1.xpath("aggregated-ether-options/lacp/periodic")[0].text, is_("slow"))
@@ -1022,7 +1020,6 @@ configuration check-out failed
                     {"name": "ae1"},
                     {"aggregated-ether-options": {
                         "link-speed": {XML_ATTRIBUTES: {"operation": "delete"}},
-                        "auto-negotiation": {XML_ATTRIBUTES: {"operation": "delete"}},
                         "lacp": {
                             "active": {XML_ATTRIBUTES: {"operation": "delete"}},
                             "periodic": "slow"}}},
@@ -1148,6 +1145,89 @@ configuration check-out failed
         assert_that(ge002, is_(None))
 
         self.cleanup(vlan("VLAN2995"), reset_interface("ae1"), reset_interface("ge-0/0/1"), reset_interface("ge-0/0/2"))
+
+    def test_auto_negotiation_and_no_auti_negotiation_are_mutually_exclusive(self):
+        self.edit({
+            "interfaces": [
+                {"interface": [
+                    {"name": "ge-0/0/1"},
+                    {"ether-options": {
+                        "auto-negotiation": {}}}]}]})
+        self.nc.commit()
+
+        ge001 = self.get_interface("ge-0/0/1")
+        assert_that(ge001.xpath("ether-options/auto-negotiation"), has_length(1))
+        assert_that(ge001.xpath("ether-options/no-auto-negotiation"), has_length(0))
+
+        self.edit({
+            "interfaces": [
+                {"interface": [
+                    {"name": "ge-0/0/1"},
+                    {"ether-options": {
+                        "no-auto-negotiation": {}}}]}]})
+        self.nc.commit()
+
+        ge001 = self.get_interface("ge-0/0/1")
+        assert_that(ge001.xpath("ether-options/auto-negotiation"), has_length(0))
+        assert_that(ge001.xpath("ether-options/no-auto-negotiation"), has_length(1))
+
+        self.edit({
+            "interfaces": [
+                {"interface": [
+                    {"name": "ge-0/0/1"},
+                    {"ether-options": {
+                        "no-auto-negotiation": {XML_ATTRIBUTES: {"operation": "delete"}}}}]}]})
+        self.nc.commit()
+
+        assert_that(self.get_interface("ge-0/0/1"), is_(None))
+
+    def test_posting_delete_on_both_auto_negotiation_flags_delete_and_raises(self):
+        with self.assertRaises(RPCError) as expect:
+            self.edit({
+                "interfaces": [
+                    {"interface": [
+                        {"name": "ge-0/0/1"},
+                        {"ether-options": {
+                            "auto-negotiation": {XML_ATTRIBUTES: {"operation": "delete"}},
+                            "no-auto-negotiation": {XML_ATTRIBUTES: {"operation": "delete"}}}}]}]})
+
+        assert_that(str(expect.exception), contains_string("warning: statement not found: no-auto-negotiation"))
+        assert_that(str(expect.exception), contains_string("warning: statement not found: auto-negotiation"))
+
+        with self.assertRaises(RPCError) as expect:
+            self.edit({
+                "interfaces": [
+                    {"interface": [
+                        {"name": "ge-0/0/1"},
+                        {"ether-options": {
+                            "auto-negotiation": {},
+                            "no-auto-negotiation": {}}}]}]})
+
+        assert_that(str(expect.exception), contains_string("syntax error"))
+
+        self.edit({
+            "interfaces": [
+                {"interface": [
+                    {"name": "ge-0/0/1"},
+                    {"ether-options": {
+                        "auto-negotiation": {}}}]}]})
+        self.nc.commit()
+
+        with self.assertRaises(RPCError) as expect:
+            self.edit({
+                "interfaces": [
+                    {"interface": [
+                        {"name": "ge-0/0/1"},
+                        {"ether-options": {
+                            "auto-negotiation": {XML_ATTRIBUTES: {"operation": "delete"}},
+                            "no-auto-negotiation": {XML_ATTRIBUTES: {"operation": "delete"}}}}]}]})
+        self.nc.commit()
+
+        assert_that(str(expect.exception), contains_string("warning: statement not found: no-auto-negotiation"))
+        assert_that(str(expect.exception), is_not(contains_string("warning: statement not found: auto-negotiation")))
+
+        e = self.get_interface("ge-0/0/1")
+        assert_that(e, is_(None))
 
     def test_compare_configuration(self):
 


### PR DESCRIPTION
To more precisely exert the behavior of the real switch
the auto-negotiation on aggregated ports have been removed
a support for auto-negotiation and no-auto-negotiation
has been added to interface along with their delete

A support for multiple errors was introduced because that's
how the switch behave when given the 2 options at the same
time