### PR TITLE
Fix the case of error messages

### DIFF
--- a/fake_switches/netconf/__init__.py
+++ b/fake_switches/netconf/__init__.py
@@ -137,17 +137,17 @@ class AggregatePortOutOfRange(NetconfError):
 
 class PhysicalPortOutOfRange(NetconfError):
     def __init__(self, port, interface):
-        super(PhysicalPortOutOfRange, self).__init__("Port value outside range 1..127 for '{}' in '{}'".format(port, interface))
+        super(PhysicalPortOutOfRange, self).__init__("port value outside range 1..127 for '{}' in '{}'".format(port, interface))
 
 
 class InvalidTrailingInput(NetconfError):
     def __init__(self, port, interface):
-        super(InvalidTrailingInput, self).__init__("Invalid trailing input '{}' in '{}'".format(port, interface))
+        super(InvalidTrailingInput, self).__init__("invalid trailing input '{}' in '{}'".format(port, interface))
 
 
 class InvalidInterfaceType(NetconfError):
     def __init__(self, interface):
-        super(InvalidInterfaceType, self).__init__("Invalid interface type in '{}'".format(interface))
+        super(InvalidInterfaceType, self).__init__("invalid interface type in '{}'".format(interface))
 
 
 class OperationNotSupported(NetconfError):

--- a/tests/juniper/juniper_base_protocol_test.py
+++ b/tests/juniper/juniper_base_protocol_test.py
@@ -1045,37 +1045,45 @@ class JuniperBaseProtocolTest(BaseJuniper):
             self.edit({
                 "interfaces": {
                     "interface": [
-                        {"name": "ge-0/0/43foobar"}
+                        {"name": "ge-0/0/43foobar"},
+                        {"ether-options": {
+                            "auto-negotiation": {}}}
                     ]}})
 
-        assert_that(str(exc.exception), contains_string("Invalid trailing input 'foobar' in 'ge-0/0/43foobar'"))
+        assert_that(str(exc.exception), contains_string("invalid trailing input 'foobar' in 'ge-0/0/43foobar'"))
 
     def test_set_interface_raises_for_physical_interface_for_out_of_range_port(self):
         with self.assertRaises(RPCError) as exc:
             self.edit({
                 "interfaces": {
                     "interface": [
-                        {"name": "ge-0/0/128"}
+                        {"name": "ge-0/0/128"},
+                        {"ether-options": {
+                            "auto-negotiation": {}}}
                     ]}})
 
-        assert_that(str(exc.exception), contains_string("Port value outside range 1..127 for '128' in 'ge-0/0/128'"))
+        assert_that(str(exc.exception), contains_string("port value outside range 1..127 for '128' in 'ge-0/0/128'"))
 
     def test_set_interface_raises_on_aggregated_invalid_interface_type(self):
         with self.assertRaises(RPCError) as exc:
             self.edit({
                 "interfaces": {
                     "interface": [
-                        {"name": "ae34foobar345"}
+                        {"name": "ae34foobar345"},
+                        {"ether-options": {
+                            "auto-negotiation": {}}}
                     ]}})
 
-        assert_that(str(exc.exception), contains_string("Invalid interface type in 'ae34foobar345'"))
+        assert_that(str(exc.exception), contains_string("invalid interface type in 'ae34foobar345'"))
 
     def test_set_interface_raises_on_aggregated_out_of_range_port(self):
         with self.assertRaises(RPCError) as exc:
             self.edit({
                 "interfaces": {
                     "interface": [
-                        {"name": "ae34345"}
+                        {"name": "ae34345"},
+                        {"aggregated-ether-options": {
+                            "link-speed": "10g"}}
                     ]}})
         assert_that(str(exc.exception), contains_string("device value outside range 0..127 for '34345' in 'ae34345'"))
 

--- a/tests/juniper_qfx_copper/juniper_qfx_copper_protocol_test.py
+++ b/tests/juniper_qfx_copper/juniper_qfx_copper_protocol_test.py
@@ -970,7 +970,9 @@ configuration check-out failed
             self.edit({
                 "interfaces": {
                     "interface": [
-                        {"name": "ae9000"}
+                        {"name": "ae9000"},
+                        {"aggregated-ether-options": {
+                            "link-speed": "10g"}}
                     ]}})
         assert_that(str(exc.exception), contains_string("device value outside range 0..999 for '9000' in 'ae9000'"))
 
@@ -1365,6 +1367,42 @@ configuration check-out failed
                      reset_interface("ge-0/0/2"),
                      reset_interface("ge-0/0/3"),
                      reset_interface("ge-0/0/4"))
+
+    def test_set_interface_raises_on_physical_interface_with_bad_trailing_input(self):
+        with self.assertRaises(RPCError) as exc:
+            self.edit({
+                "interfaces": {
+                    "interface": [
+                        {"name": "ge-0/0/43foobar"},
+                        {"ether-options": {
+                            "auto-negotiation": {}}}
+                    ]}})
+
+        assert_that(str(exc.exception), contains_string("invalid trailing input 'foobar' in 'ge-0/0/43foobar'"))
+
+    def test_set_interface_raises_for_physical_interface_for_out_of_range_port(self):
+        with self.assertRaises(RPCError) as exc:
+            self.edit({
+                "interfaces": {
+                    "interface": [
+                        {"name": "ge-0/0/128"},
+                        {"ether-options": {
+                            "auto-negotiation": {}}}
+                    ]}})
+
+        assert_that(str(exc.exception), contains_string("port value outside range 1..127 for '128' in 'ge-0/0/128'"))
+
+    def test_set_interface_raises_on_aggregated_invalid_interface_type(self):
+        with self.assertRaises(RPCError) as exc:
+            self.edit({
+                "interfaces": {
+                    "interface": [
+                        {"name": "ae34foobar345"},
+                        {"ether-options": {
+                            "auto-negotiation": {}}}
+                    ]}})
+
+        assert_that(str(exc.exception), contains_string("invalid interface type in 'ae34foobar345'"))
 
 
 def reset_interface(interface_name):


### PR DESCRIPTION
They should all be starting with a lower casing