### PR TITLE
Add missing lxml dependency in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,22 @@
-FROM python:2-onbuild
+FROM python:2.7-alpine
+
+RUN apk update
+RUN apk add python-dev gcc g++ make libffi-dev openssl-dev libxml2 libxml2-dev libxslt libxslt-dev
+
+# 
+# NOTE(mmitchell): Mimick -onbuild using -alpine image.
+#                  ONBUILD statements removed because this is an actual Dockerfile
+#
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /usr/src/app
+#
+# End of -onbuild copied commands.
+#
 
 RUN PBR_VERSION=0.0.0 pip install .
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ Using it with Docker
 ====================
 
 ```shell
-$ docker run -P -d internap:fake-switches
+$ docker run -P -d internap/fake-switches
 $ docker ps
 CONTAINER ID        IMAGE                             COMMAND                  CREATED             STATUS              PORTS                     NAMES
-6eec86849561        fake-switches                     "/bin/sh -c 'fake-swi"   35 seconds ago      Up 13 seconds       0.0.0.0:32776->22/tcp     boring_thompson
+6eec86849561        internap/fake-switches            "/bin/sh -c 'fake-swi"   35 seconds ago      Up 13 seconds       0.0.0.0:32776->22/tcp     boring_thompson
 $ ssh 127.0.0.1 -p 32776 -l root
 root@127.0.0.1's password:  # root
 my_switch>enable
@@ -77,7 +77,7 @@ Launching with custom parameters
 --------------------------------
 
 ```shell
-$ docker run -P -d -e SWITCH_MODEL="another_model" internap:fake-switches
+$ docker run -P -d -e SWITCH_MODEL="another_model" internap/fake-switches
 ```
 
 Building image from source

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ tftpy>=0.6.1
 pycrypto>=2.6.1
 Twisted==15.5.0
 pyasn1>=0.1.7
+lxml>=3.7


### PR DESCRIPTION
Currently, we depend on lxml for the Juniper simulator. This requirement
wasnt in requirements.txt.

This commit adds it, switches the Docker base image to the Alpine one
and fixes the README instructions for running the container.