### PR TITLE
[docker] Allow hostname, listen host and port to be configured

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ COPY . /usr/src/app
 RUN PBR_VERSION=0.0.0 pip install .
 
 EXPOSE 22
-CMD fake-switches ${SWITCH_MODEL:-cisco_generic} 0.0.0.0 22
+CMD fake-switches ${SWITCH_MODEL:-cisco_generic} ${SWITCH_HOSTNAME:-switch} ${LISTEN_HOST:-0.0.0.0} ${LISTEN_PORT:-22}

--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ Launching with custom parameters
 $ docker run -P -d -e SWITCH_MODEL="another_model" internap/fake-switches
 ```
 
+Supported parameters
+--------------------
+
+- SWITCH_MODEL, defaults to _cisco_generic_
+- SWITCH_HOSTNAME, defaults to _switch_
+- LISTEN_HOST, defaults to _0.0.0.0_
+- LISTEN_PORT, defaults to _22_
+
+
 Building image from source
 --------------------------
 
@@ -88,8 +97,8 @@ $ docker build -t fake-switches .
 $ docker run -P -d fake-switches
 ```
 
-Making the switches more real
-=============================
+Extending functionality
+=======================
 
 The SwitchConfiguration class can be extended and given an object factory with
 custom classes that can act upon resources changes. For example :
@@ -155,7 +164,7 @@ Starting a switch from the command line
 ```shell
     pip install fake-switches
     
-    # fake-switches <model> <listen_host> <listen_port>
+    # fake-switches <model> [<hostname>] <listen_host> <listen_port>
     fake-switches cisco_generic 0.0.0.0 22222
 
     # On a different shell, type the following:

--- a/tests/cmd/test_main.py
+++ b/tests/cmd/test_main.py
@@ -14,7 +14,8 @@ TEST_BIND_PORT = str(random.randint(20000, 22000))
 
 class FakeSwitchesTest(unittest.TestCase):
     def test_fake_switches_entrypoint_cisco_generic(self):
-        p = subprocess.Popen(get_base_args() + ['cisco_generic', TEST_BIND_HOST, TEST_BIND_PORT])
+        p = subprocess.Popen(get_base_args() + ['cisco_generic', 'switch_hostname',
+                                                TEST_BIND_HOST, TEST_BIND_PORT])
 
         handshake = connect_and_read_bytes(TEST_BIND_HOST, TEST_BIND_PORT,
                                            byte_count=8, retry_count=10)
@@ -24,7 +25,8 @@ class FakeSwitchesTest(unittest.TestCase):
         assert_that(handshake, starts_with('SSH-2.0'))
 
     def test_fake_switches_entrypoint_invalid_model(self):
-        p = subprocess.Popen(get_base_args() + ['invalid_model', TEST_BIND_HOST, TEST_BIND_PORT])
+        p = subprocess.Popen(get_base_args() + ['invalid_model', 'switch_hostname',
+                                                TEST_BIND_HOST, TEST_BIND_PORT])
 
         returncode = p.wait()
 


### PR DESCRIPTION
Currently, the hostname, host and port are not configureable via the
Dockerfile.

This commit allows the settings to be configured.

Partial-bug: #89