### PR TITLE
Bump twisted version to 16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 netaddr>=0.7.13
 tftpy>=0.6.1
 pycrypto>=2.6.1
-Twisted==15.5.0
+Twisted>=16.6.0, <17.0
 pyasn1>=0.1.7
 lxml>=3.7


### PR DESCRIPTION
Twisted 15.5.0 seemed to have problems with stability and some SSH
negociation errors were happening often, The new version 16 seems to not
have this problems. This will get rid of some false-negatives.