### PR TITLE
[docker] Allow hostname, listen host/port and credentials to be confi…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,9 @@ COPY . /usr/src/app
 RUN PBR_VERSION=0.0.0 pip install .
 
 EXPOSE 22
-CMD fake-switches ${SWITCH_MODEL:-cisco_generic} 0.0.0.0 22
+CMD fake-switches --model ${SWITCH_MODEL:-cisco_generic} \
+                  --hostname ${SWITCH_HOSTNAME:-switch} \
+                  --username ${SWITCH_USERNAME:-root} \
+                  --password ${SWITCH_PASSWORD:-root} \
+                  --listen-host ${LISTEN_HOST:-0.0.0.0} \
+                  --listen-port ${LISTEN_PORT:-22}

--- a/README.md
+++ b/README.md
@@ -80,6 +80,17 @@ Launching with custom parameters
 $ docker run -P -d -e SWITCH_MODEL="another_model" internap/fake-switches
 ```
 
+Supported parameters
+--------------------
+
+- SWITCH_MODEL, defaults to _cisco_generic_
+- SWITCH_HOSTNAME, defaults to _switch_
+- SWITCH_USER, defaults to _root_
+- SWITCH_PASS, defaults to _root_
+- LISTEN_HOST, defaults to _0.0.0.0_
+- LISTEN_PORT, defaults to _22_
+
+
 Building image from source
 --------------------------
 
@@ -88,8 +99,8 @@ $ docker build -t fake-switches .
 $ docker run -P -d fake-switches
 ```
 
-Making the switches more real
-=============================
+Extending functionality
+=======================
 
 The SwitchConfiguration class can be extended and given an object factory with
 custom classes that can act upon resources changes. For example :
@@ -155,20 +166,44 @@ Starting a switch from the command line
 ```shell
     pip install fake-switches
     
-    # fake-switches <model> <listen_host> <listen_port>
-    fake-switches cisco_generic 0.0.0.0 22222
+    fake-switches
 
     # On a different shell, type the following:
     ssh root@127.0.0.1 -p 22222
 ```
 
-You can replace cisco_generic by any other supported switch model.
+Command line help
+-----------------
+
+The --help flag is supported.
+
+    fake-switches --help
+    usage: fake-switches [-h] [--model MODEL] [--hostname HOSTNAME]
+                         [--username USERNAME] [--password PASSWORD]
+                         [--listen-host LISTEN_HOST] [--listen-port LISTEN_PORT]
+
+    Fake-switch simulator launcher
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      --model MODEL         Switch model, allowed values are
+                            juniper_qfx_copper_generic, cisco_2960_24TT_L,
+                            dell_generic, dell10g_generic, juniper_generic,
+                            cisco_2960_48TT_L, cisco_generic, brocade_generic
+                            (default: cisco_generic)
+      --hostname HOSTNAME   Switch hostname (default: switch)
+      --username USERNAME   Switch username (default: root)
+      --password PASSWORD   Switch password (default: root)
+      --listen-host LISTEN_HOST
+                            Listen host (default: 0.0.0.0)
+      --listen-port LISTEN_PORT
+                            Listen port (default: 2222)
 
 
 Available switch models
 -----------------------
 
-The following models are available:
+At time of writing this document, the following models are available:
  
   * brocade_generic
   * cisco_generic
@@ -178,6 +213,8 @@ The following models are available:
   * dell10g_generic
   * juniper_generic
   * juniper_qfx_copper_generic
+
+Use the --help flag to find the available models.
 
 The generic models are mainly for test purposes. They usually have less ports than a proper switch
 model but behave the same otherwise. Once a "core" is available, more specific models can be very

--- a/fake_switches/cmd/main.py
+++ b/fake_switches/cmd/main.py
@@ -1,29 +1,41 @@
 import argparse
+import logging
+
 
 from fake_switches import switch_factory
 from fake_switches.ssh_service import SwitchSshService
 from twisted.internet import reactor
 
 
+logging.basicConfig(level='DEBUG')
+logger = logging.getLogger()
+
+# NOTE(mmitchell): This is necessary because some imports will initialize the root logger.
+logger.setLevel('DEBUG')
+
 def main():
-    parser = argparse.ArgumentParser(description='Fake-switch simulator launcher')
-    parser.add_argument('model', type=str, help='Switch model')
-    parser.add_argument('hostname', type=str, nargs='?', help='Switch hostname')
-    parser.add_argument('listen_host', type=str, help='Listen host')
-    parser.add_argument('listen_port', type=int, help='Listen port')
+    parser = argparse.ArgumentParser(description='Fake-switch simulator launcher',
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('--model', type=str, default='cisco_generic',
+                        help='Switch model, allowed values are ' + ', '.join(switch_factory.DEFAULT_MAPPING.keys()))
+    parser.add_argument('--hostname', type=str, default='switch', help='Switch hostname')
+    parser.add_argument('--username', type=str, default='root', help='Switch username')
+    parser.add_argument('--password', type=str, default='root', help='Switch password')
+    parser.add_argument('--listen-host', type=str, default='0.0.0.0', help='Listen host')
+    parser.add_argument('--listen-port', type=int, default=2222, help='Listen port')
 
     args = parser.parse_args()
 
     factory = switch_factory.SwitchFactory()
-    hostname = args.hostname or 'hostname.invalid'
-    switch_core = factory.get(args.model, hostname)
+    switch_core = factory.get(args.model, args.hostname, args.password)
 
     ssh_service = SwitchSshService(
         ip=args.listen_host,
-        ssh_port=int(args.listen_port),
-        switch_core=switch_core)
+        ssh_port=args.listen_port,
+        switch_core=switch_core,
+        users={args.username: args.password})
     ssh_service.hook_to_reactor(reactor)
 
-    print('Starting reactor')
+    logger.info('Starting reactor')
     reactor.run()
 

--- a/fake_switches/ssh_service.py
+++ b/fake_switches/ssh_service.py
@@ -50,7 +50,7 @@ class SSHDemoAvatar(avatar.ConchUser):
     def closed(self):
         pass
 
-    def windowChanged(newWindowSize):
+    def windowChanged(self, newWindowSize):
         pass
 
     def eofReceived(self):

--- a/fake_switches/switch_factory.py
+++ b/fake_switches/switch_factory.py
@@ -24,7 +24,7 @@ class SwitchFactory(object):
             mapping = DEFAULT_MAPPING
         self.mapping = mapping
 
-    def get(self, switch_model, hostname='switch_hostname'):
+    def get(self, switch_model, hostname='switch_hostname', password='root'):
         try:
             core = self.mapping[switch_model]
         except KeyError:
@@ -34,6 +34,7 @@ class SwitchFactory(object):
             switch_configuration.SwitchConfiguration(
                 '127.0.0.1',
                 name=hostname,
+                privileged_passwords=[password],
                 ports=core.get_default_ports())
         )
 

--- a/tests/cmd/test_main.py
+++ b/tests/cmd/test_main.py
@@ -14,7 +14,8 @@ TEST_BIND_PORT = str(random.randint(20000, 22000))
 
 class FakeSwitchesTest(unittest.TestCase):
     def test_fake_switches_entrypoint_cisco_generic(self):
-        p = subprocess.Popen(get_base_args() + ['cisco_generic', TEST_BIND_HOST, TEST_BIND_PORT])
+        p = subprocess.Popen(get_base_args() + ["--listen-host", TEST_BIND_HOST,
+                                                "--listen-port", TEST_BIND_PORT])
 
         handshake = connect_and_read_bytes(TEST_BIND_HOST, TEST_BIND_PORT,
                                            byte_count=8, retry_count=10)
@@ -24,7 +25,9 @@ class FakeSwitchesTest(unittest.TestCase):
         assert_that(handshake, starts_with('SSH-2.0'))
 
     def test_fake_switches_entrypoint_invalid_model(self):
-        p = subprocess.Popen(get_base_args() + ['invalid_model', TEST_BIND_HOST, TEST_BIND_PORT])
+        p = subprocess.Popen(get_base_args() + ["--listen-host", TEST_BIND_HOST,
+                                                "--listen-port", TEST_BIND_PORT,
+                                                "--model", "invalid_model"])
 
         returncode = p.wait()
 

--- a/tests/test_switch_factory.py
+++ b/tests/test_switch_factory.py
@@ -28,5 +28,6 @@ class SwitchFactoryTest(unittest.TestCase):
         assert_that(switch, is_(instance_of(switch_core.SwitchCore)))
         switch_conf_class.assert_called_with('127.0.0.1',
                                              name='my_hostname',
-                                             ports=mock.sentinel.port_list)
+                                             ports=mock.sentinel.port_list,
+                                             privileged_passwords=['root'])
         core_mock.assert_called_with(switch_conf_instance)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
 envlist = py27
+skipsdist = True
 
 [testenv]
+usedevelop = True
 deps = -r{toxinidir}/test-requirements.txt
 commands = python setup.py nosetests


### PR DESCRIPTION
…gured

Currently, the hostname, host/port, and credentials are not
configureable via the Dockerfile.

This commit allows all settings to be configured individually.

Closes-bug: #89