### PR TITLE
Enables docker image testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,27 @@
 language: python
 
+dist: trusty
+sudo: required
+
+services:
+  - docker
+
 matrix:
   include:
     - python: "2.7"
-      env: TOX_ENV=py27
+      env:
+        - TOX_ENV=py27
+        - DOCKER_COMPOSE_VERSION=1.10.0
     - python: "3.5"
-      env: TOX_ENV=py35
+      env:
+        - TOX_ENV=py35
+        - DOCKER_COMPOSE_VERSION=1.10.0
+
+before_install:
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +rx docker-compose
+  - sudo mv docker-compose /usr/local/bin
 
 addons:
   apt:
@@ -17,7 +33,11 @@ install:
   - pip install -r requirements.txt
   - pip install -r test-requirements.txt
 
-script: tox -e $TOX_ENV
+script: 
+  - tox -e $TOX_ENV
+  - docker build . -t internap/fake-switches:latest
+  - docker-compose up -d
+  - docker inspect -f {{.State.Running}} fakeswitches_tor1.yul1.example.net_1
 
 deploy:
   provider: pypi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM python:2.7-alpine
 
-RUN apk update
-RUN apk add python-dev gcc g++ make libffi-dev openssl-dev libxml2 libxml2-dev libxslt libxslt-dev
+RUN apk update && apk add --no-cache python-dev gcc git g++ make libffi-dev openssl-dev libxml2 libxml2-dev libxslt libxslt-dev
 
 # 
 # NOTE(mmitchell): Mimick -onbuild using -alpine image.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '2'
+
+services:
+  tsr1.yul1.example.net:
+    image: "internap/fake-switches:latest"
+    environment:
+      - SWITCH_MODEL=cisco_2960_48TT_L
+
+  tor1.yul1.example.net:
+    image: "internap/fake-switches:latest"
+    environment:
+      - SWITCH_MODEL=cisco_2960_48TT_L

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pycrypto>=2.6.1
 Twisted>=16.6.0, <17.0
 pyasn1>=0.1.7
 lxml>=3.7
+cryptography>=1.7.1


### PR DESCRIPTION
The docker image is now build using travis. A docker-compose
example file is provided which is used by travis to make sure
the previously built image is working. If a container refuses
to start, travis will mark the build as failed.