### PR TITLE
Use twisted to get cryptography

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 -e git+https://github.com/stephanerobert/tftpy.git@master#egg=tftpy
 netaddr>=0.7.13
-pycrypto>=2.6.1
-Twisted>=16.6.0, <17.0
+Twisted[conch]>=16.6.0, <17.0
 pyasn1>=0.1.7
 lxml>=3.7
-cryptography>=1.7.1


### PR DESCRIPTION
There is no need for a separate dependency, twisted[conch] contains all
the requirements for using ssl with twisted.