### PR TITLE
Fix password encoding for python 3 in main()

### DIFF
--- a/fake_switches/cmd/main.py
+++ b/fake_switches/cmd/main.py
@@ -25,6 +25,7 @@ def main():
     parser.add_argument('--listen-port', type=int, default=2222, help='Listen port')
 
     args = parser.parse_args()
+    args.password = args.password.encode()
 
     factory = switch_factory.SwitchFactory()
     switch_core = factory.get(args.model, args.hostname, args.password)

--- a/fake_switches/ssh_service.py
+++ b/fake_switches/ssh_service.py
@@ -112,7 +112,7 @@ class SwitchSshService(object):
         ssh_factory = factory.SSHFactory()
         ssh_factory.portal = portal.Portal(SSHDemoRealm(self.switch_core))
         if not self.users:
-            self.users = {'root': 'root'}
+            self.users = {'root': b'root'}
         ssh_factory.portal.registerChecker(
             checkers.InMemoryUsernamePasswordDatabaseDontUse(**self.users))
 

--- a/tests/cmd/test_main.py
+++ b/tests/cmd/test_main.py
@@ -1,18 +1,35 @@
+import os
+import random
 import socket
 import subprocess
 import sys
 import time
 import unittest
-import random
 
-import os
 from hamcrest import assert_that, is_not, starts_with
+
+from tests.util.protocol_util import SshTester
 
 TEST_BIND_HOST = '127.0.0.1'
 TEST_BIND_PORT = str(random.randint(20000, 22000))
+TEST_HOSTNAME = 'root'
+TEST_PASSWORD = 'root'
 
 
 class FakeSwitchesTest(unittest.TestCase):
+    def test_fake_switches_password_encoding(self):
+        p = subprocess.Popen(get_base_args() + ["--listen-host", TEST_BIND_HOST,
+                                                "--listen-port", TEST_BIND_PORT,
+                                                "--hostname", TEST_HOSTNAME,
+                                                "--password", TEST_PASSWORD])
+        time.sleep(1)
+
+        ssh = SshTester("ssh-2", TEST_BIND_HOST, TEST_BIND_PORT, TEST_HOSTNAME, TEST_PASSWORD)
+        ssh.connect()
+        ssh.disconnect()
+
+        p.terminate()
+
     def test_fake_switches_entrypoint_cisco_generic(self):
         p = subprocess.Popen(get_base_args() + ["--listen-host", TEST_BIND_HOST,
                                                 "--listen-port", TEST_BIND_PORT])

--- a/tests/util/global_reactor.py
+++ b/tests/util/global_reactor.py
@@ -65,14 +65,14 @@ class ThreadedReactor(threading.Thread):
             SwitchConfiguration(cisco_switch_ip, name="my_switch", privileged_passwords=[cisco_privileged_password],
                                 ports=CiscoSwitchCore.get_default_ports()))
         SwitchTelnetService(cisco_switch_ip, telnet_port=cisco_switch_telnet_port, switch_core=switch_core,
-                            users={'root': 'root'}).hook_to_reactor(cls._threaded_reactor.reactor)
+                            users={'root': b'root'}).hook_to_reactor(cls._threaded_reactor.reactor)
         SwitchSshService(cisco_switch_ip, ssh_port=cisco_switch_ssh_port, switch_core=switch_core,
                          users={'root': b'root'}).hook_to_reactor(cls._threaded_reactor.reactor)
 
         auto_enabled_switch_core = CiscoSwitchCore(
             SwitchConfiguration(cisco_switch_ip, name="my_switch", auto_enabled=True))
         SwitchTelnetService(cisco_switch_ip, telnet_port=cisco_auto_enabled_switch_telnet_port,
-                            switch_core=auto_enabled_switch_core, users={'root': 'root'}).hook_to_reactor(
+                            switch_core=auto_enabled_switch_core, users={'root': b'root'}).hook_to_reactor(
             cls._threaded_reactor.reactor)
         SwitchSshService(cisco_switch_ip, ssh_port=cisco_auto_enabled_switch_ssh_port,
                          switch_core=auto_enabled_switch_core, users={'root': b'root'}).hook_to_reactor(


### PR DESCRIPTION
When using main(), the password was not encoded causing a type error in Python3