### PR TITLE
Add support for cisco's standby version command

### DIFF
--- a/fake_switches/cisco/command_processor/enabled.py
+++ b/fake_switches/cisco/command_processor/enabled.py
@@ -287,6 +287,8 @@ def build_running_interface(port):
             data.append(" no ip redirects")
         if port.ip_proxy_arp is False:
             data.append(" no ip proxy-arp")
+        if port.vrrp_version is not None:
+            data.append(" standby version {}".format(port.vrrp_version))
         for vrrp in port.vrrps:
             group = vrrp.group_id
             if vrrp.ip_addresses is not None:

--- a/fake_switches/switch_configuration.py
+++ b/fake_switches/switch_configuration.py
@@ -206,6 +206,7 @@ class VlanPort(Port):
         self.ips = []
         self.secondary_ips = []
         self.vrrp_common_authentication = None
+        self.vrrp_version = None
         self.vrrps = []
         self.ip_redirect = True
         self.ip_proxy_arp = True


### PR DESCRIPTION
Version 1 is default.
Version 2 is the only other one supported at the
moment and is the only one to appear in the running-config