### PR TITLE
Refactor the global reactor

### DIFF
--- a/fake_switches/juniper_qfx_copper/juniper_qfx_copper_core.py
+++ b/fake_switches/juniper_qfx_copper/juniper_qfx_copper_core.py
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from fake_switches.juniper.juniper_core import JuniperSwitchCore
+from fake_switches.juniper.juniper_core import BaseJuniperSwitchCore
 from fake_switches.juniper_qfx_copper.juniper_qfx_copper_netconf_datastore import JuniperQfxCopperNetconfDatastore
 
 
-class JuniperQfxCopperSwitchCore(JuniperSwitchCore):
-    def __init__(self, switch_configuration, aggregated_port_count=24):
+class JuniperQfxCopperSwitchCore(BaseJuniperSwitchCore):
+    def __init__(self, switch_configuration):
         super(JuniperQfxCopperSwitchCore, self).__init__(
             switch_configuration,
-            datastore_class=JuniperQfxCopperNetconfDatastore,
-            aggregated_port_count=aggregated_port_count)
+            datastore_class=JuniperQfxCopperNetconfDatastore)

--- a/fake_switches/switch_factory.py
+++ b/fake_switches/switch_factory.py
@@ -1,6 +1,7 @@
+from fake_switches import switch_configuration
 from fake_switches.brocade import brocade_core
 from fake_switches.cisco import cisco_core
-from fake_switches import switch_configuration
+from fake_switches.cisco6500 import cisco_core as cisco6500_core
 from fake_switches.dell import dell_core
 from fake_switches.dell10g import dell_core as dell10g_core
 from fake_switches.juniper import juniper_core
@@ -10,10 +11,11 @@ from fake_switches.juniper_qfx_copper import juniper_qfx_copper_core
 DEFAULT_MAPPING = {
     'brocade_generic': brocade_core.BrocadeSwitchCore,
     'cisco_generic': cisco_core.CiscoSwitchCore,
+    'cisco_6500': cisco6500_core.Cisco6500SwitchCore,
     'cisco_2960_24TT_L': cisco_core.Cisco2960_24TT_L_SwitchCore,
     'cisco_2960_48TT_L': cisco_core.Cisco2960_48TT_L_SwitchCore,
     'dell_generic': dell_core.DellSwitchCore,
-    'dell10g_generic': dell10g_core.DellSwitchCore,
+    'dell10g_generic': dell10g_core.Dell10GSwitchCore,
     'juniper_generic': juniper_core.JuniperSwitchCore,
     'juniper_qfx_copper_generic': juniper_qfx_copper_core.JuniperQfxCopperSwitchCore,
     'juniper_mx_generic': juniper_mx_core.JuniperMXSwitchCore
@@ -26,7 +28,7 @@ class SwitchFactory(object):
             mapping = DEFAULT_MAPPING
         self.mapping = mapping
 
-    def get(self, switch_model, hostname='switch_hostname', password='root'):
+    def get(self, switch_model, hostname='switch_hostname', password='root', ports=None, **kwargs):
         try:
             core = self.mapping[switch_model]
         except KeyError:
@@ -37,7 +39,9 @@ class SwitchFactory(object):
                 '127.0.0.1',
                 name=hostname,
                 privileged_passwords=[password],
-                ports=core.get_default_ports())
+                ports=ports or core.get_default_ports(),
+                **kwargs
+            )
         )
 
 

--- a/tests/brocade/test_brocade_switch_protocol.py
+++ b/tests/brocade/test_brocade_switch_protocol.py
@@ -1,24 +1,16 @@
-import unittest
-
-from flexmock import flexmock_teardown
-from tests.util.global_reactor import brocade_switch_ip, \
-    brocade_switch_ssh_port, brocade_privileged_password
 import mock
-from tests.util.protocol_util import SshTester, with_protocol
+from tests.util.protocol_util import SshTester, with_protocol, ProtocolTest
 
 
-class TestBrocadeSwitchProtocol(unittest.TestCase):
-    def setUp(self):
-        self.protocol = SshTester("ssh", brocade_switch_ip, brocade_switch_ssh_port, 'root', 'root')
-
-    def tearDown(self):
-        flexmock_teardown()
+class TestBrocadeSwitchProtocol(ProtocolTest):
+    tester_class = SshTester
+    test_switch = "brocade"
 
     @with_protocol
     def test_enable_command_requires_a_password(self, t):
         t.write("enable")
         t.read("Password:")
-        t.write_invisible(brocade_privileged_password)
+        t.write_invisible(t.conf["extra"]["password"])
         t.read("SSH@my_switch#")
 
     @with_protocol
@@ -40,7 +32,7 @@ class TestBrocadeSwitchProtocol(unittest.TestCase):
     def test_exiting_loses_the_connection(self, t):
         t.write("enable")
         t.read("Password:")
-        t.write_invisible(brocade_privileged_password)
+        t.write_invisible(t.conf["extra"]["password"])
         t.read("SSH@my_switch#")
         t.write("exit")
         t.read_eof()
@@ -1527,10 +1519,11 @@ class TestBrocadeSwitchProtocol(unittest.TestCase):
 
         remove_vlan(t, "1201")
 
+
 def enable(t):
     t.write("enable")
     t.read("Password:")
-    t.write_invisible(brocade_privileged_password)
+    t.write_invisible(t.conf["extra"].get("password", "root"))
     t.read("SSH@my_switch#")
 
 

--- a/tests/brocade/test_brocade_switch_protocol_with_commit_delay.py
+++ b/tests/brocade/test_brocade_switch_protocol_with_commit_delay.py
@@ -12,22 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 import time
 
-from flexmock import flexmock_teardown
 from hamcrest import assert_that, greater_than
-from tests.util.global_reactor import brocade_switch_ip, brocade_privileged_password, brocade_switch_with_commit_delay_ssh_port, \
-    COMMIT_DELAY
-from tests.util.protocol_util import SshTester, with_protocol
+from tests.brocade.test_brocade_switch_protocol import enable
+from tests.util.global_reactor import COMMIT_DELAY
+from tests.util.protocol_util import SshTester, with_protocol, ProtocolTest
 
 
-class TestBrocadeSwitchProtocolWithCommitDelay(unittest.TestCase):
-    def setUp(self):
-        self.protocol = SshTester("ssh", brocade_switch_ip, brocade_switch_with_commit_delay_ssh_port, 'root', 'root')
-
-    def tearDown(self):
-        flexmock_teardown()
+class TestBrocadeSwitchProtocolWithCommitDelay(ProtocolTest):
+    tester_class = SshTester
+    test_switch = "commit-delayed-brocade"
 
     @with_protocol
     def test_write_memory(self, t):
@@ -42,10 +37,3 @@ class TestBrocadeSwitchProtocolWithCommitDelay(unittest.TestCase):
         end_time = time.time()
 
         assert_that((end_time - start_time), greater_than(COMMIT_DELAY))
-
-
-def enable(t):
-    t.write("enable")
-    t.read("Password:")
-    t.write_invisible(brocade_privileged_password)
-    t.read("SSH@my_switch#")

--- a/tests/cisco/__init__.py
+++ b/tests/cisco/__init__.py
@@ -1,10 +1,7 @@
-from tests.util.global_reactor import cisco_privileged_password
-
-
 def enable(t):
     t.write("enable")
     t.read("Password: ")
-    t.write_invisible(cisco_privileged_password)
+    t.write_invisible(t.conf["extra"].get("password", "root"))
     t.read("my_switch#")
 
 

--- a/tests/cisco/test_cisco_auto_enabled_switch.py
+++ b/tests/cisco/test_cisco_auto_enabled_switch.py
@@ -1,19 +1,9 @@
-import unittest
-
-from flexmock import flexmock_teardown
-from tests.util.global_reactor import cisco_switch_ip, \
-    cisco_auto_enabled_switch_ssh_port, cisco_auto_enabled_switch_telnet_port
-from tests.util.protocol_util import SshTester, TelnetTester, with_protocol
+from tests.util.protocol_util import SshTester, TelnetTester, with_protocol, ProtocolTest
 
 
-class TestCiscoAutoEnabledSwitchProtocol(unittest.TestCase):
+class TestCiscoAutoEnabledSwitchProtocol(ProtocolTest):
     __test__ = False
-
-    def setUp(self):
-        self.protocol = self.create_client()
-
-    def tearDown(self):
-        flexmock_teardown()
+    test_switch = "cisco-auto-enabled"
 
     @with_protocol
     def test_enable_command_requires_a_password(self, t):
@@ -29,19 +19,12 @@ class TestCiscoAutoEnabledSwitchProtocol(unittest.TestCase):
         t.write("exit")
         t.read("my_switch#")
 
-    def create_client(self):
-        raise NotImplementedError()
-
 
 class TestCiscoSwitchProtocolSSH(TestCiscoAutoEnabledSwitchProtocol):
     __test__ = True
-
-    def create_client(self):
-        return SshTester("ssh", cisco_switch_ip, cisco_auto_enabled_switch_ssh_port, u'root', u'root')
+    tester_class = SshTester
 
 
 class TestCiscoSwitchProtocolTelnet(TestCiscoAutoEnabledSwitchProtocol):
     __test__ = True
-
-    def create_client(self):
-        return TelnetTester("telnet", cisco_switch_ip, cisco_auto_enabled_switch_telnet_port, u'root', u'root')
+    tester_class = TelnetTester

--- a/tests/cisco/test_cisco_switch_protocol.py
+++ b/tests/cisco/test_cisco_switch_protocol.py
@@ -12,36 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-
 import mock
-from flexmock import flexmock_teardown
 
 from tests.cisco import enable, create_interface_vlan, configuring, configuring_interface_vlan, \
     assert_interface_configuration, remove_vlan, create_vlan, set_interface_on_vlan, configuring_interface, \
     revert_switchport_mode_access, create_port_channel_interface, configuring_port_channel
-from tests.util.global_reactor import cisco_privileged_password
-from tests.util.global_reactor import cisco_switch_ssh_port, cisco_switch_telnet_port, cisco_switch_ip
-from tests.util.protocol_util import SshTester, TelnetTester, with_protocol
+from tests.util.protocol_util import SshTester, TelnetTester, with_protocol, ProtocolTest
 
 
-class TestCiscoSwitchProtocol(unittest.TestCase):
+class TestCiscoSwitchProtocol(ProtocolTest):
     __test__ = False
-
-    def create_client(self):
-        return SshTester("ssh", cisco_switch_ip, cisco_switch_ssh_port, u'root', u'root')
-
-    def setUp(self):
-        self.protocol = self.create_client()
-
-    def tearDown(self):
-        flexmock_teardown()
+    test_switch = "cisco"
 
     @with_protocol
     def test_enable_command_requires_a_password(self, t):
         t.write("enable")
         t.read("Password: ")
-        t.write_invisible(cisco_privileged_password)
+        t.write_invisible(t.conf["extra"]["password"])
         t.read("my_switch#")
 
     @with_protocol
@@ -64,7 +51,7 @@ class TestCiscoSwitchProtocol(unittest.TestCase):
     def test_exiting_loses_the_connection(self, t):
         t.write("enable")
         t.read("Password: ")
-        t.write_invisible(cisco_privileged_password)
+        t.write_invisible(t.conf["extra"]["password"])
         t.read("my_switch#")
         t.write("exit")
         t.read_eof()
@@ -1522,13 +1509,9 @@ class TestCiscoSwitchProtocol(unittest.TestCase):
 
 class TestCiscoSwitchProtocolSSH(TestCiscoSwitchProtocol):
     __test__ = True
-
-    def create_client(self):
-        return SshTester("ssh", cisco_switch_ip, cisco_switch_ssh_port, u'root', u'root')
+    tester_class = SshTester
 
 
 class TestCiscoSwitchProtocolTelnet(TestCiscoSwitchProtocol):
     __test__ = True
-
-    def create_client(self):
-        return TelnetTester("telnet", cisco_switch_ip, cisco_switch_telnet_port, u'root', u'root')
+    tester_class = TelnetTester

--- a/tests/cisco/test_cisco_switch_protocol_with_commit_delay.py
+++ b/tests/cisco/test_cisco_switch_protocol_with_commit_delay.py
@@ -12,29 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 from time import time
 
-from flexmock import flexmock_teardown
 from hamcrest import assert_that
 from hamcrest import greater_than
-
 from tests.cisco import enable
-from tests.util.global_reactor import cisco_switch_ip
-from tests.util.global_reactor import cisco_switch_ssh_with_commit_delay_port, COMMIT_DELAY
-from tests.util.protocol_util import SshTester, with_protocol
+from tests.util.global_reactor import COMMIT_DELAY
+from tests.util.protocol_util import SshTester, with_protocol, ProtocolTest
 
 
-class TestCiscoSwitchProtocolWithCommitDelay(unittest.TestCase):
-
-    def create_client(self):
-        return SshTester("ssh", cisco_switch_ip, cisco_switch_ssh_with_commit_delay_port, 'root', 'root')
-
-    def setUp(self):
-        self.protocol = self.create_client()
-
-    def tearDown(self):
-        flexmock_teardown()
+class TestCiscoSwitchProtocolWithCommitDelay(ProtocolTest):
+    tester_class = SshTester
+    test_switch = "commit-delayed-cisco"
 
     @with_protocol
     def test_write_memory_with_commit_delay(self, t):

--- a/tests/cisco/test_cisco_unicast.py
+++ b/tests/cisco/test_cisco_unicast.py
@@ -12,28 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-
-from flexmock import flexmock_teardown
-
 from tests.cisco import enable, create_interface_vlan, configuring, configuring_interface_vlan, \
     assert_interface_configuration
-from tests.util.global_reactor import cisco_switch_ssh_port, cisco_switch_telnet_port, cisco_switch_ip
-from tests.util.protocol_util import SshTester, TelnetTester, with_protocol
+from tests.util.protocol_util import SshTester, TelnetTester, with_protocol, ProtocolTest
 
 
-class CiscoUnicastTest(unittest.TestCase):
+class CiscoUnicastTest(ProtocolTest):
     __test__ = False
-
-    def create_client(self):
-        return SshTester("ssh", cisco_switch_ip, cisco_switch_ssh_port, u'root', u'root')
-
-    def setUp(self):
-        self.protocol = self.create_client()
-
-    def tearDown(self):
-        flexmock_teardown()
-
+    test_switch = "cisco"
 
     @with_protocol
     def test_set_unicast_raise_error(self, t):
@@ -84,13 +70,9 @@ class CiscoUnicastTest(unittest.TestCase):
 
 class CiscoUnicastProtocolSSHTest(CiscoUnicastTest):
     __test__ = True
-
-    def create_client(self):
-        return SshTester("ssh", cisco_switch_ip, cisco_switch_ssh_port, u'root', u'root')
+    tester_class = SshTester
 
 
 class CiscoUnicastProtocolTelnetTest(CiscoUnicastTest):
     __test__ = True
-
-    def create_client(self):
-        return TelnetTester("telnet", cisco_switch_ip, cisco_switch_telnet_port, u'root', u'root')
+    tester_class = TelnetTester

--- a/tests/cisco6500/test_cisco6500_unicast.py
+++ b/tests/cisco6500/test_cisco6500_unicast.py
@@ -12,28 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-
-from flexmock import flexmock_teardown
-
 from tests.cisco import enable, create_interface_vlan, configuring, configuring_interface_vlan, \
     assert_interface_configuration
-from tests.util.global_reactor import cisco6500_switch_ip, cisco6500_switch_telnet_port, \
-    cisco6500_switch_ssh_port
-from tests.util.protocol_util import SshTester, TelnetTester, with_protocol
+from tests.util.protocol_util import SshTester, TelnetTester, with_protocol, ProtocolTest
 
 
-class Cisco6500UnicastTest(unittest.TestCase):
+class Cisco6500UnicastTest(ProtocolTest):
     __test__ = False
 
-    def create_client(self):
-        return SshTester("ssh", cisco6500_switch_ip, cisco6500_switch_ssh_port, u'root', u'root')
-
-    def setUp(self):
-        self.protocol = self.create_client()
-
-    def tearDown(self):
-        flexmock_teardown()
+    tester_class = SshTester
+    test_switch = "cisco6500"
 
     @with_protocol
     def test_set_unicast(self, t):
@@ -60,13 +48,9 @@ class Cisco6500UnicastTest(unittest.TestCase):
 
 class Cisco6500UnicastProtocolSSHTest(Cisco6500UnicastTest):
     __test__ = True
-
-    def create_client(self):
-        return SshTester("ssh", cisco6500_switch_ip, cisco6500_switch_ssh_port, u'root', u'root')
+    tester_class = SshTester
 
 
 class Cisco6500UnicastProtocolTelnetTest(Cisco6500UnicastTest):
     __test__ = True
-
-    def create_client(self):
-        return TelnetTester("telnet", cisco6500_switch_ip, cisco6500_switch_telnet_port, u'root', u'root')
+    tester_class = TelnetTester

--- a/tests/cmd/test_main.py
+++ b/tests/cmd/test_main.py
@@ -1,5 +1,4 @@
 import os
-import random
 import socket
 import subprocess
 import sys
@@ -7,11 +6,11 @@ import time
 import unittest
 
 from hamcrest import assert_that, is_not, starts_with
-
+from tests.util import _unique_port
 from tests.util.protocol_util import SshTester
 
 TEST_BIND_HOST = '127.0.0.1'
-TEST_BIND_PORT = str(random.randint(20000, 22000))
+TEST_BIND_PORT = str(_unique_port())
 TEST_HOSTNAME = 'root'
 TEST_PASSWORD = 'root'
 

--- a/tests/dell/__init__.py
+++ b/tests/dell/__init__.py
@@ -12,26 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from hamcrest import assert_that, is_
 import pprint
 
-from tests.util.global_reactor import dell_privileged_password, dell_switch_ip, \
-    dell_switch_ssh_port, dell_switch_telnet_port
-from tests.util.protocol_util import SshTester, TelnetTester
-
-
-def ssh_protocol_factory(*_):
-    return SshTester("ssh", dell_switch_ip, dell_switch_ssh_port, 'root', 'root')
-
-
-def telnet_protocol_factory(*_):
-    return TelnetTester("ssh", dell_switch_ip, dell_switch_telnet_port, 'root', 'root')
+from hamcrest import assert_that, is_
 
 
 def enable(t):
     t.write("enable")
     t.read("Password:")
-    t.write_stars(dell_privileged_password)
+    t.write_stars(t.conf["extra"].get("password", "root"))
     t.readln("")
     t.read("my_switch#")
 

--- a/tests/dell/test_configure.py
+++ b/tests/dell/test_configure.py
@@ -12,24 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-
-from flexmock import flexmock_teardown
-
-from tests.dell import enable, configure, configuring_vlan, unconfigure_vlan, \
-    ssh_protocol_factory, telnet_protocol_factory
-from tests.util.protocol_util import with_protocol
+from tests.dell import enable, configure, configuring_vlan, unconfigure_vlan
+from tests.util.protocol_util import with_protocol, ProtocolTest, SshTester, TelnetTester
 
 
-class DellConfigureTest(unittest.TestCase):
+class DellConfigureTest(ProtocolTest):
     __test__ = False
-    protocol_factory = None
 
-    def setUp(self):
-        self.protocol = self.protocol_factory()
-
-    def tearDown(self):
-        flexmock_teardown()
+    tester_class = SshTester
+    test_switch = "dell"
 
     @with_protocol
     def test_entering_configure_interface_mode(self, t):
@@ -95,9 +86,9 @@ class DellConfigureTest(unittest.TestCase):
 
 class DellConfigureSshTest(DellConfigureTest):
     __test__ = True
-    protocol_factory = ssh_protocol_factory 
+    tester_class = SshTester
 
 
 class DellConfigureTelnetTest(DellConfigureTest):
     __test__ = True
-    protocol_factory = telnet_protocol_factory
+    tester_class = TelnetTester

--- a/tests/dell/test_configure_interface.py
+++ b/tests/dell/test_configure_interface.py
@@ -12,28 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-
-from flexmock import flexmock_teardown
 from hamcrest import assert_that, is_not, has_item
 
 from tests.dell import enable, configuring_interface, \
     assert_interface_configuration, assert_running_config_contains_in_order, \
     get_running_config, configure, configuring_vlan, unconfigure_vlan, \
     configuring_a_vlan_on_interface, create_bond, remove_bond, \
-    ssh_protocol_factory, telnet_protocol_factory, configuring_bond
-from tests.util.protocol_util import with_protocol
+    configuring_bond
+from tests.util.protocol_util import with_protocol, ProtocolTest, SshTester, TelnetTester
 
 
-class DellConfigureInterfaceTest(unittest.TestCase):
+class DellConfigureInterfaceTest(ProtocolTest):
     __test__ = False
-    protocol_factory = ssh_protocol_factory
 
-    def setUp(self):
-        self.protocol = self.protocol_factory()
-
-    def tearDown(self):
-        flexmock_teardown()
+    tester_class = SshTester
+    test_switch = "dell"
 
     @with_protocol
     def test_show_run_vs_show_run_interface_same_output(self, t):
@@ -1003,11 +996,12 @@ class DellConfigureInterfaceTest(unittest.TestCase):
 
         remove_bond(t, 1)
 
+
 class DellConfigureInterfaceSshTest(DellConfigureInterfaceTest):
     __test__ = True
-    protocol_factory = ssh_protocol_factory
+    tester_class = SshTester
 
 
 class DellConfigureInterfaceTelnetTest(DellConfigureInterfaceTest):
     __test__ = True
-    protocol_factory = telnet_protocol_factory
+    tester_class = TelnetTester

--- a/tests/dell/test_configure_vlan.py
+++ b/tests/dell/test_configure_vlan.py
@@ -12,26 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-
-from flexmock import flexmock_teardown
-
 from tests.dell import enable, configuring_vlan, \
     assert_running_config_contains_in_order, unconfigure_vlan, \
-    assert_interface_configuration, ssh_protocol_factory,\
-    telnet_protocol_factory
-from tests.util.protocol_util import with_protocol
+    assert_interface_configuration
+from tests.util.protocol_util import with_protocol, ProtocolTest, SshTester, TelnetTester
 
 
-class DellConfigureVlanTest(unittest.TestCase):
+class DellConfigureVlanTest(ProtocolTest):
     __test__ = False
-    protocol_factory = None
 
-    def setUp(self):
-        self.protocol = self.protocol_factory()
-
-    def tearDown(self):
-        flexmock_teardown()
+    tester_class = SshTester
+    test_switch = "dell"
 
     @with_protocol
     def test_configuring_a_vlan(self, t):
@@ -128,9 +119,9 @@ class DellConfigureVlanTest(unittest.TestCase):
 
 class DellConfigureVlanSshTest(DellConfigureVlanTest):
     __test__ = True
-    protocol_factory = ssh_protocol_factory
+    tester_class = SshTester
 
 
 class DellConfigureVlanTelnetTest(DellConfigureVlanTest):
     __test__ = True
-    protocol_factory = telnet_protocol_factory
+    tester_class = TelnetTester

--- a/tests/dell/test_enabled.py
+++ b/tests/dell/test_enabled.py
@@ -12,25 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-
-from flexmock import flexmock_teardown
-
 from tests.dell import enable, assert_running_config_contains_in_order, \
     configuring_vlan, configuring_interface_vlan, unconfigure_vlan, \
-    ssh_protocol_factory, telnet_protocol_factory, configuring_a_vlan_on_interface, configuring_interface
-from tests.util.protocol_util import with_protocol
+    configuring_a_vlan_on_interface, configuring_interface
+from tests.util.protocol_util import with_protocol, ProtocolTest, SshTester, TelnetTester
 
 
-class DellEnabledTest(unittest.TestCase):
+class DellEnabledTest(ProtocolTest):
     __test__ = False
-    protocol_factory = ssh_protocol_factory
 
-    def setUp(self):
-        self.protocol = self.protocol_factory()
-
-    def tearDown(self):
-        flexmock_teardown()
+    tester_class = SshTester
+    test_switch = "dell"
 
     @with_protocol
     def test_exit_returns_to_unprivileged_mode(self, t):
@@ -354,9 +346,9 @@ class DellEnabledTest(unittest.TestCase):
 
 class DellEnabledSshTest(DellEnabledTest):
     __test__ = True
-    protocol_factory = ssh_protocol_factory
+    tester_class = SshTester
 
 
 class DellEnabledTelnetTest(DellEnabledTest):
     __test__ = True
-    protocol_factory = telnet_protocol_factory
+    tester_class = TelnetTester

--- a/tests/dell/test_enabled_with_commit_delay.py
+++ b/tests/dell/test_enabled_with_commit_delay.py
@@ -14,22 +14,16 @@
 
 from time import time
 
-import unittest
-
-from flexmock import flexmock_teardown
 from hamcrest import assert_that, less_than, greater_than
-
 from tests.dell import enable
-from tests.util.protocol_util import with_protocol, SshTester
-from tests.util.global_reactor import COMMIT_DELAY, dell_switch_ip, dell_switch_with_commit_delay_ssh_port
+from tests.util.global_reactor import COMMIT_DELAY
+from tests.util.protocol_util import with_protocol, SshTester, ProtocolTest
 
 
-class DellEnabledWithCommitDelayTest(unittest.TestCase):
-    def setUp(self):
-        self.protocol = SshTester("ssh", dell_switch_ip, dell_switch_with_commit_delay_ssh_port, 'root', 'root')
+class DellEnabledWithCommitDelayTest(ProtocolTest):
 
-    def tearDown(self):
-        flexmock_teardown()
+    tester_class = SshTester
+    test_switch = "commit-delayed-dell"
 
     @with_protocol
     def test_write_memory_with_delay(self, t):

--- a/tests/dell/test_unprivileged.py
+++ b/tests/dell/test_unprivileged.py
@@ -12,30 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-
-from flexmock import flexmock_teardown
-
-from tests.dell import ssh_protocol_factory, telnet_protocol_factory
-from tests.util.global_reactor import dell_privileged_password
-from tests.util.protocol_util import with_protocol
+from tests.util.protocol_util import with_protocol, ProtocolTest, SshTester, TelnetTester
 
 
-class DellUnprivilegedTest(unittest.TestCase):
+class DellUnprivilegedTest(ProtocolTest):
     __test__ = False
-    protocol_factory = None
 
-    def setUp(self):
-        self.protocol = self.protocol_factory()
-
-    def tearDown(self):
-        flexmock_teardown()
+    tester_class = SshTester
+    test_switch = "dell"
 
     @with_protocol
     def test_entering_enable_mode_requires_a_password(self, t):
         t.write("enable")
         t.read("Password:")
-        t.write_stars(dell_privileged_password)
+        t.write_stars(t.conf["extra"]["password"])
         t.read("\r\n")
         t.read("my_switch#")
 
@@ -68,9 +58,9 @@ class DellUnprivilegedTest(unittest.TestCase):
 
 class DellUnprivilegedSshTest(DellUnprivilegedTest):
     __test__ = True
-    protocol_factory = ssh_protocol_factory
+    tester_class = SshTester
 
 
 class DellUnprivilegedTelnetTest(DellUnprivilegedTest):
     __test__ = True
-    protocol_factory = telnet_protocol_factory
+    tester_class = TelnetTester

--- a/tests/dell10g/__init__.py
+++ b/tests/dell10g/__init__.py
@@ -16,23 +16,11 @@ import pprint
 
 from hamcrest import assert_that, is_
 
-from tests.util.global_reactor import dell10g_privileged_password, dell10g_switch_ip, \
-    dell10g_switch_ssh_port, dell10g_switch_telnet_port
-from tests.util.protocol_util import SshTester, TelnetTester
-
-
-def ssh_protocol_factory(*_):
-    return SshTester("ssh", dell10g_switch_ip, dell10g_switch_ssh_port, 'root', 'root')
-
-
-def telnet_protocol_factory(*_):
-    return TelnetTester("ssh", dell10g_switch_ip, dell10g_switch_telnet_port, 'root', 'root')
-
 
 def enable(t):
     t.write("enable")
     t.read("Password:")
-    t.write_stars(dell10g_privileged_password)
+    t.write_stars(t.conf["extra"].get("password", "root"))
     t.readln("")
     t.read("my_switch#")
 

--- a/tests/dell10g/test_configure.py
+++ b/tests/dell10g/test_configure.py
@@ -12,23 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-
-from flexmock import flexmock_teardown
-
-from tests.dell10g import enable, ssh_protocol_factory, telnet_protocol_factory
-from tests.util.protocol_util import with_protocol
+from tests.dell10g import enable
+from tests.util.protocol_util import with_protocol, ProtocolTest, SshTester, TelnetTester
 
 
-class Dell10GConfigureTest(unittest.TestCase):
+class Dell10GConfigureTest(ProtocolTest):
     __test__ = False
-    protocol_factory = None
 
-    def setUp(self):
-        self.protocol = self.protocol_factory()
-
-    def tearDown(self):
-        flexmock_teardown()
+    tester_class = SshTester
+    test_switch = "dell10g"
 
     @with_protocol
     def test_entering_configure_unknown_interface_mode(self, t):
@@ -91,9 +83,9 @@ class Dell10GConfigureTest(unittest.TestCase):
 
 class Dell10GConfigureSshTest(Dell10GConfigureTest):
     __test__ = True
-    protocol_factory = ssh_protocol_factory 
+    tester_class = SshTester
 
 
 class Dell10GConfigureTelnetTest(Dell10GConfigureTest):
     __test__ = True
-    protocol_factory = telnet_protocol_factory
+    tester_class = TelnetTester

--- a/tests/dell10g/test_configure_interface.py
+++ b/tests/dell10g/test_configure_interface.py
@@ -12,25 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-
-from flexmock import flexmock_teardown
 from hamcrest import assert_that, is_not, has_item
 
 from tests.dell10g import enable, assert_interface_configuration, assert_running_config_contains_in_order, \
-    get_running_config, configuring_interface, ssh_protocol_factory, telnet_protocol_factory, add_vlan, configuring, \
+    get_running_config, configuring_interface, add_vlan, configuring, \
     remove_bond, create_bond
-from tests.util.protocol_util import with_protocol
+from tests.util.protocol_util import with_protocol, ProtocolTest, SshTester, TelnetTester
 
 
-class Dell10GConfigureInterfaceSshTest(unittest.TestCase):
-    protocol_factory = ssh_protocol_factory
-
-    def setUp(self):
-        self.protocol = self.protocol_factory()
-
-    def tearDown(self):
-        flexmock_teardown()
+class Dell10GConfigureInterfaceSshTest(ProtocolTest):
+    tester_class = SshTester
+    test_switch = "dell10g"
 
     @with_protocol
     def test_show_run_vs_show_run_interface_same_output(self, t):
@@ -692,6 +684,5 @@ class Dell10GConfigureInterfaceSshTest(unittest.TestCase):
         t.read("my_switch#")
 
 
-
 class Dell10GConfigureInterfaceTelnetTest(Dell10GConfigureInterfaceSshTest):
-    protocol_factory = telnet_protocol_factory
+    tester_class = TelnetTester

--- a/tests/dell10g/test_configure_vlan.py
+++ b/tests/dell10g/test_configure_vlan.py
@@ -12,25 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-
-from flexmock import flexmock_teardown
-
 from tests.dell10g import enable, configuring_vlan, \
-    assert_running_config_contains_in_order, ssh_protocol_factory,\
-    telnet_protocol_factory, add_vlan, configuring
-from tests.util.protocol_util import with_protocol
+    assert_running_config_contains_in_order, add_vlan, configuring
+from tests.util.protocol_util import with_protocol, ProtocolTest, SshTester, TelnetTester
 
 
-class Dell10GConfigureVlanTest(unittest.TestCase):
+class Dell10GConfigureVlanTest(ProtocolTest):
     __test__ = False
-    protocol_factory = None
 
-    def setUp(self):
-        self.protocol = self.protocol_factory()
-
-    def tearDown(self):
-        flexmock_teardown()
+    tester_class = SshTester
+    test_switch = "dell10g"
 
     @with_protocol
     def test_configuring_a_vlan(self, t):
@@ -55,9 +46,9 @@ class Dell10GConfigureVlanTest(unittest.TestCase):
 
 class Dell10GConfigureVlanSshTest(Dell10GConfigureVlanTest):
     __test__ = True
-    protocol_factory = ssh_protocol_factory
+    tester_class = SshTester
 
 
 class Dell10GConfigureVlanTelnetTest(Dell10GConfigureVlanTest):
     __test__ = True
-    protocol_factory = telnet_protocol_factory
+    tester_class = TelnetTester

--- a/tests/dell10g/test_enabled.py
+++ b/tests/dell10g/test_enabled.py
@@ -12,24 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-
-from flexmock import flexmock_teardown
-
 from tests.dell10g import enable, assert_running_config_contains_in_order, \
-    configuring_vlan, ssh_protocol_factory, telnet_protocol_factory, configuring, add_vlan, configuring_interface
-from tests.util.protocol_util import with_protocol
+    configuring_vlan, configuring, add_vlan, configuring_interface
+from tests.util.protocol_util import with_protocol, SshTester, ProtocolTest, TelnetTester
 
 
-class Dell10GEnabledTest(unittest.TestCase):
+class Dell10GEnabledTest(ProtocolTest):
     __test__ = False
-    protocol_factory = None
 
-    def setUp(self):
-        self.protocol = ssh_protocol_factory()
-
-    def tearDown(self):
-        flexmock_teardown()
+    tester_class = SshTester
+    test_switch = "dell10g"
 
     @with_protocol
     def test_terminal_length_0(self, t):
@@ -271,9 +263,9 @@ class Dell10GEnabledTest(unittest.TestCase):
 
 class Dell10GEnabledSshTest(Dell10GEnabledTest):
     __test__ = True
-    protocol_factory = ssh_protocol_factory
+    tester_class = SshTester
 
 
 class Dell10GEnabledTelnetTest(Dell10GEnabledTest):
     __test__ = True
-    protocol_factory = telnet_protocol_factory
+    tester_class = TelnetTester

--- a/tests/dell10g/test_enabled_with_commit_delay.py
+++ b/tests/dell10g/test_enabled_with_commit_delay.py
@@ -14,22 +14,16 @@
 
 from time import time
 
-import unittest
-
-from flexmock import flexmock_teardown
 from hamcrest import greater_than, assert_that, less_than
-
 from tests.dell10g import enable
-from tests.util.protocol_util import with_protocol, SshTester
-from tests.util.global_reactor import dell10g_switch_ip, dell10g_switch_with_commit_delay_ssh_port, COMMIT_DELAY
+from tests.util.global_reactor import COMMIT_DELAY
+from tests.util.protocol_util import with_protocol, SshTester, ProtocolTest
 
 
-class Dell10GEnabledWithCommitDelayTest(unittest.TestCase):
-    def setUp(self):
-        self.protocol = SshTester("ssh", dell10g_switch_ip, dell10g_switch_with_commit_delay_ssh_port, 'root', 'root')
+class Dell10GEnabledWithCommitDelayTest(ProtocolTest):
 
-    def tearDown(self):
-        flexmock_teardown()
+    tester_class = SshTester
+    test_switch = "commit-delayed-dell10g"
 
     @with_protocol
     def test_write_memory_with_commit_delay(self, t):

--- a/tests/dell10g/test_unprivileged.py
+++ b/tests/dell10g/test_unprivileged.py
@@ -12,30 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-
-from flexmock import flexmock_teardown
-
-from tests.dell10g import ssh_protocol_factory, telnet_protocol_factory
-from tests.util.global_reactor import dell10g_privileged_password
-from tests.util.protocol_util import with_protocol
+from tests.util.protocol_util import with_protocol, ProtocolTest, SshTester, TelnetTester
 
 
-class Dell10GUnprivilegedTest(unittest.TestCase):
+class Dell10GUnprivilegedTest(ProtocolTest):
     __test__ = False
-    protocol_factory = None
 
-    def setUp(self):
-        self.protocol = self.protocol_factory()
-
-    def tearDown(self):
-        flexmock_teardown()
+    tester_class = SshTester
+    test_switch = "dell10g"
 
     @with_protocol
     def test_entering_enable_mode_requires_a_password(self, t):
         t.write("enable")
         t.read("Password:")
-        t.write_stars(dell10g_privileged_password)
+        t.write_stars(t.conf["extra"]["password"])
         t.read("\r\n")
         t.read("my_switch#")
 
@@ -68,9 +58,9 @@ class Dell10GUnprivilegedTest(unittest.TestCase):
 
 class Dell10GUnprivilegedSshTest(Dell10GUnprivilegedTest):
     __test__ = True
-    protocol_factory = ssh_protocol_factory
+    tester_class = SshTester
 
 
 class Dell10GUnprivilegedTelnetTest(Dell10GUnprivilegedTest):
     __test__ = True
-    protocol_factory = telnet_protocol_factory
+    tester_class = TelnetTester

--- a/tests/juniper/__init__.py
+++ b/tests/juniper/__init__.py
@@ -2,12 +2,26 @@ import unittest
 
 from fake_switches.netconf import dict_2_etree, XML_ATTRIBUTES
 from hamcrest import assert_that, has_length
+from ncclient import manager
+from tests.util.global_reactor import TEST_SWITCHES
 
 
 class BaseJuniper(unittest.TestCase):
+    test_switch = None
 
     def setUp(self):
+        self.conf = TEST_SWITCHES[self.test_switch]
         self.nc = self.create_client()
+
+    def create_client(self):
+        return manager.connect(
+            host="127.0.0.1",
+            port=self.conf["ssh"],
+            username="root",
+            password="root",
+            hostkey_verify=False,
+            device_params={'name': 'junos'}
+        )
 
     def tearDown(self):
         assert_that(self.nc.get_config(source="running").xpath("data/configuration/*"), has_length(0))

--- a/tests/juniper/juniper_base_protocol_test.py
+++ b/tests/juniper/juniper_base_protocol_test.py
@@ -13,30 +13,18 @@
 # limitations under the License.
 
 
+from fake_switches.netconf import dict_2_etree, XML_ATTRIBUTES, XML_TEXT
 from hamcrest import assert_that, has_length, has_items, equal_to, is_, is_not, contains_string
-from ncclient import manager
 from ncclient.operations import RPCError
 from ncclient.xml_ import to_xml
-
-from fake_switches.netconf import dict_2_etree, XML_ATTRIBUTES, XML_TEXT
 from tests import contains_regex
 from tests.juniper import BaseJuniper, vlan
 from tests.juniper.assertion_tools import has_xpath
 from tests.netconf.netconf_protocol_test import xml_equals_to
-from tests.util.global_reactor import juniper_switch_ip, juniper_switch_netconf_port
 
 
 class JuniperBaseProtocolTest(BaseJuniper):
-
-    def create_client(self):
-        return manager.connect(
-            host=juniper_switch_ip,
-            port=juniper_switch_netconf_port,
-            username="root",
-            password="root",
-            hostkey_verify=False,
-            device_params={'name': 'junos'}
-        )
+    test_switch = "juniper"
 
     def test_capabilities(self):
         assert_that(self.nc.server_capabilities, has_items(

--- a/tests/juniper/juniper_base_protocol_with_commit_delay_test.py
+++ b/tests/juniper/juniper_base_protocol_with_commit_delay_test.py
@@ -13,35 +13,15 @@
 # limitations under the License.
 
 from time import time
-import unittest
 
-from hamcrest import assert_that, has_length, greater_than
-
-from ncclient import manager
-from tests.util.global_reactor import juniper_switch_ip, \
-    juniper_switch_netconf_with_commit_delay_port, COMMIT_DELAY
 from fake_switches.netconf import dict_2_etree, XML_ATTRIBUTES
+from hamcrest import assert_that, has_length, greater_than
+from tests.juniper import BaseJuniper
+from tests.util.global_reactor import COMMIT_DELAY
 
 
-class JuniperBaseProtocolWithCommitDelayTest(unittest.TestCase):
-    def setUp(self):
-        self.nc = self.create_client()
-
-    def tearDown(self):
-        try:
-            self.nc.discard_changes()
-        finally:
-            self.nc.close_session()
-
-    def create_client(self):
-        return manager.connect(
-            host=juniper_switch_ip,
-            port=juniper_switch_netconf_with_commit_delay_port,
-            username="root",
-            password="root",
-            hostkey_verify=False,
-            device_params={'name': 'junos'}
-        )
+class JuniperBaseProtocolWithCommitDelayTest(BaseJuniper):
+    test_switch = "commit-delayed-juniper"
 
     def test_lock_edit_candidate_add_vlan_and_commit_with_commit_delay(self):
         with self.nc.locked(target='candidate'):

--- a/tests/juniper_mx/juniper_mx_protocol_test.py
+++ b/tests/juniper_mx/juniper_mx_protocol_test.py
@@ -11,32 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from hamcrest import assert_that, has_length, has_items, equal_to, is_, is_not, contains_string
-from lxml import etree
-from ncclient import manager
-from ncclient.operations import RPCError
-
 from fake_switches.netconf import dict_2_etree, XML_ATTRIBUTES, XML_TEXT
+from hamcrest import assert_that, has_length, has_items, equal_to, is_, contains_string
+from lxml import etree
+from ncclient.operations import RPCError
 from tests import contains_regex
 from tests.juniper import BaseJuniper
 from tests.juniper.assertion_tools import has_xpath
 from tests.juniper_qfx_copper.juniper_qfx_copper_protocol_test import reset_interface
 from tests.netconf.netconf_protocol_test import xml_equals_to
-from tests.util.global_reactor import juniper_mx_switch_ip, \
-    juniper_mx_switch_netconf_port
 
 
 class JuniperMXProtocolTest(BaseJuniper):
-
-    def create_client(self):
-        return manager.connect(
-            host=juniper_mx_switch_ip,
-            port=juniper_mx_switch_netconf_port,
-            username="root",
-            password="root",
-            hostkey_verify=False,
-            device_params={'name': 'junos'}
-        )
+    test_switch = "juniper_mx"
 
     def test_capabilities(self):
         assert_that(list(self.nc.server_capabilities), has_items(

--- a/tests/juniper_qfx_copper/juniper_qfx_copper_protocol_test.py
+++ b/tests/juniper_qfx_copper/juniper_qfx_copper_protocol_test.py
@@ -13,32 +13,18 @@
 # limitations under the License.
 
 
-from tests.juniper import BaseJuniper, vlan
-from lxml import etree
-
 from fake_switches.netconf import dict_2_etree, XML_TEXT, XML_ATTRIBUTES
 from hamcrest import assert_that, has_length, equal_to, has_items, is_, is_not, contains_string
-from ncclient import manager
+from lxml import etree
 from ncclient.operations import RPCError
 from tests import contains_regex
+from tests.juniper import BaseJuniper, vlan
 from tests.juniper.assertion_tools import has_xpath
 from tests.netconf.netconf_protocol_test import xml_equals_to
 
-from tests.util.global_reactor import juniper_qfx_copper_switch_ip, \
-    juniper_qfx_copper_switch_netconf_port
-
 
 class JuniperQfxCopperProtocolTest(BaseJuniper):
-
-    def create_client(self):
-        return manager.connect(
-            host=juniper_qfx_copper_switch_ip,
-            port=juniper_qfx_copper_switch_netconf_port,
-            username="root",
-            password="root",
-            hostkey_verify=False,
-            device_params={'name': 'junos'}
-        )
+    test_switch = "juniper_qfx"
 
     def test_capabilities(self):
         assert_that(self.nc.server_capabilities, has_items(

--- a/tests/test_simultaneous_connections.py
+++ b/tests/test_simultaneous_connections.py
@@ -1,20 +1,19 @@
 import unittest
 
-from tests.util.global_reactor import brocade_privileged_password, cisco_privileged_password
-from tests.util.global_reactor import brocade_switch_ip, brocade_switch_ssh_port, cisco_switch_ip, \
-    cisco_switch_telnet_port
+from tests.util.global_reactor import TEST_SWITCHES
 from tests.util.protocol_util import SshTester, TelnetTester
 
 
 class RoutingEngineTest(unittest.TestCase):
     def test_2_ssh(self):
-        tester1 = SshTester("ssh-1", brocade_switch_ip, brocade_switch_ssh_port, u'root', u'root')
-        tester2 = SshTester("ssh-2", brocade_switch_ip, brocade_switch_ssh_port, u'root', u'root')
+        conf = TEST_SWITCHES["brocade"]
+        tester1 = SshTester("ssh-1", "127.0.0.1", conf["ssh"], u'root', u'root')
+        tester2 = SshTester("ssh-2", "127.0.0.1", conf["ssh"], u'root', u'root')
 
         tester1.connect()
         tester1.write("enable")
         tester1.read("Password:")
-        tester1.write_invisible(brocade_privileged_password)
+        tester1.write_invisible(conf["extra"]["password"])
         tester1.read("SSH@my_switch#")
         tester1.write("skip-page-display")
         tester1.read("SSH@my_switch#")
@@ -26,7 +25,7 @@ class RoutingEngineTest(unittest.TestCase):
 
         tester2.write("enable")
         tester2.read("Password:")
-        tester2.write_invisible(brocade_privileged_password)
+        tester2.write_invisible(conf["extra"]["password"])
         tester2.read("SSH@my_switch#")
         tester2.write("configure terminal")
         tester2.read("SSH@my_switch(config)#")
@@ -46,13 +45,14 @@ class RoutingEngineTest(unittest.TestCase):
         tester2.disconnect()
 
     def test_2_telnet(self):
-        tester1 = TelnetTester("telnet-1", cisco_switch_ip, cisco_switch_telnet_port, 'root', 'root')
-        tester2 = TelnetTester("telnet-2", cisco_switch_ip, cisco_switch_telnet_port, 'root', 'root')
+        conf = TEST_SWITCHES["cisco"]
+        tester1 = TelnetTester("telnet-1", "127.0.0.1", conf["telnet"], 'root', 'root')
+        tester2 = TelnetTester("telnet-2", "127.0.0.1", conf["telnet"], 'root', 'root')
 
         tester1.connect()
         tester1.write("enable")
         tester1.read("Password: ")
-        tester1.write_invisible(cisco_privileged_password)
+        tester1.write_invisible(conf["extra"]["password"])
         tester1.read("my_switch#")
         tester1.write("terminal length 0")
         tester1.read("my_switch#")
@@ -64,7 +64,7 @@ class RoutingEngineTest(unittest.TestCase):
 
         tester2.write("enable")
         tester2.read("Password: ")
-        tester2.write_invisible(cisco_privileged_password)
+        tester2.write_invisible(conf["extra"]["password"])
         tester2.read("my_switch#")
         tester2.write("configure terminal")
         tester2.readln("Enter configuration commands, one per line.  End with CNTL/Z.")

--- a/tests/util/__init__.py
+++ b/tests/util/__init__.py
@@ -1,0 +1,14 @@
+from fake_switches.switch_configuration import Port, AggregatedPort
+
+_unique_port_index = 20000
+
+
+def _unique_port():
+    global _unique_port_index
+    _unique_port_index += 1
+    return _unique_port_index
+
+
+def _juniper_ports_with_less_ae():
+    return [Port("ge-0/0/{}".format(i)) for i in range(1, 5)] + \
+           [AggregatedPort("ae{}".format(i)) for i in range(1, 5)]


### PR DESCRIPTION
It's about time this thing gets a little sexier.

The test switches are now in a normalized structure, less clunky than
instantiating all the stuff, and they use the global mapping so that no
more switch is forgotten in that list.

All the tests using the test switches now have a member defining which
switch it's using and the base test classes can create the right clients
according to the configuration. This allowed the introduction of random
port numbers.

To achieve this, a contract change was required:
- The juniper switches don't create their own ports anymore, it will be
the user's responsibility for this, this is a contract change that will
trigger a major version update