### PR TITLE
Add basic vrrp groups support for juniper mx

### DIFF
--- a/fake_switches/switch_configuration.py
+++ b/fake_switches/switch_configuration.py
@@ -195,6 +195,7 @@ class VRRP(object):
         self.preempt_delay_minimum = None
         self.activated = None
         self.advertising = None
+        self.related_ip_network = None
 
 
 class VlanPort(Port):


### PR DESCRIPTION
Supports adding a VIP and a priority, more fields to come
Since VRRPs can technically be attached to anything, it was easier
for rendering to keep a record of which IP it belongs to.
Seemed easier than to try and reverse engineer from the vip to which
subnet it would belong.