### PR TITLE
ntp disable support on Cisco 6500

### DIFF
--- a/fake_switches/cisco/command_processor/enabled.py
+++ b/fake_switches/cisco/command_processor/enabled.py
@@ -270,6 +270,8 @@ def build_running_interface(port):
         data.append(" channel-group %s mode active" % last_number(port.aggregation_membership))
     if port.vrf:
         data.append(" ip vrf forwarding %s" % port.vrf.name)
+    if port.ntp is False:
+        data.append(" ntp disable")
     if isinstance(port, VlanPort):
         if len(port.ips) > 0:
             for ip in port.ips[1:]:

--- a/fake_switches/cisco6500/cisco_core.py
+++ b/fake_switches/cisco6500/cisco_core.py
@@ -20,3 +20,11 @@ class Cisco6500SwitchCore(BaseCiscoSwitchCore):
 class Cisco6500ConfigInterfaceCommandProcessor(ConfigInterfaceCommandProcessor):
     def _handle_ip_verify_unicast(self):
         self.port.unicast_reverse_path_forwarding = True
+
+    def do_ntp(self, *args):
+        if args[0] == "disable":
+            self.port.ntp = False
+
+    def do_no_ntp(self, *args):
+        if args[0] == "disable":
+            self.port.ntp = None

--- a/fake_switches/switch_configuration.py
+++ b/fake_switches/switch_configuration.py
@@ -175,6 +175,7 @@ class Port(object):
         self.lldp_med_transmit_network_policy = None
         self.spanning_tree = None
         self.spanning_tree_portfast = None
+        self.ntp = None
 
     def get_subname(self, length):
         name, number = split_port_name(self.name)

--- a/tests/cisco6500/test_cisco6500_switch_interface.py
+++ b/tests/cisco6500/test_cisco6500_switch_interface.py
@@ -1,0 +1,40 @@
+# Copyright 2018 Internap.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from tests.cisco import enable, assert_interface_configuration, configuring_interface
+from tests.util.protocol_util import SshTester, with_protocol, ProtocolTest
+
+
+class TestCiscoSwitchInterface(ProtocolTest):
+    __test__ = True
+
+    tester_class = SshTester
+    test_switch = "cisco6500"
+
+    @with_protocol
+    def test_disable_ntp(self, t):
+        enable(t)
+
+        configuring_interface(t, "FastEthernet 0/3", do="ntp disable")
+
+        assert_interface_configuration(t, "FastEthernet0/3", [
+            "interface FastEthernet0/3",
+            " ntp disable",
+            "end"])
+
+        configuring_interface(t, "FastEthernet 0/3", do="no ntp disable")
+
+        assert_interface_configuration(t, "FastEthernet0/3", [
+            "interface FastEthernet0/3",
+            "end"])
+


### PR DESCRIPTION
This is the implementation of "ntp disable" and "no ntp disable" for
the Cisco 6500