### PR TITLE
Add the support for errors in json format

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -10,14 +10,12 @@ asn1crypto==0.24.0        # via cryptography
 cffi==1.11.5              # via cryptography
 constantly==15.1.0        # via twisted
 cryptography==2.3.1       # via twisted
-enum34==1.1.6             # via cryptography
 idna==2.7                 # via cryptography
 incremental==17.5.0       # via twisted
-ipaddress==1.0.22         # via cryptography
-lxml==4.2.4
+lxml==4.2.5
 netaddr==0.7.19
 pyasn1==0.4.4             # via twisted
-pycparser==2.18           # via cffi
+pycparser==2.19           # via cffi
 six==1.11.0               # via cryptography
 twisted[conch]==16.6.0
 zope.interface==4.5.0     # via twisted

--- a/fake_switches/arista/arista_core.py
+++ b/fake_switches/arista/arista_core.py
@@ -14,10 +14,13 @@
 
 import logging
 
+from twisted.web import resource
+
 from fake_switches.arista.command_processor.config import ConfigCommandProcessor
 from fake_switches.arista.command_processor.config_vlan import ConfigVlanCommandProcessor
 from fake_switches.arista.command_processor.default import DefaultCommandProcessor
 from fake_switches.arista.command_processor.enabled import EnabledCommandProcessor
+from fake_switches.arista.eapi import EAPI
 from fake_switches.command_processing.piping_processor_base import NotPipingProcessor
 from fake_switches.command_processing.shell_session import ShellSession
 from fake_switches.switch_core import SwitchCore
@@ -61,6 +64,15 @@ class AristaSwitchCore(SwitchCore):
 
     def get_netconf_protocol(self):
         return None
+
+    def get_http_resource(self):
+        root = resource.Resource()
+        root.putChild(b'command-api', EAPI(
+            switch_configuration=self.switch_configuration,
+            command_processor=DefaultCommandProcessor(self.new_command_processor()),
+            logger=logging.getLogger("fake_switches.arista.{}.eapi".format(self.switch_configuration.name))
+        ))
+        return root
 
 
 class AristaShellSession(ShellSession):

--- a/fake_switches/arista/command_processor/__init__.py
+++ b/fake_switches/arista/command_processor/__init__.py
@@ -1,0 +1,7 @@
+
+def vlan_name(vlan):
+    return vlan.name or ("default" if vlan.number == 1 else None)
+
+
+def vlan_display_name(vlan):
+    return vlan_name(vlan) or "VLAN{:04d}".format(vlan.number)

--- a/fake_switches/arista/command_processor/__init__.py
+++ b/fake_switches/arista/command_processor/__init__.py
@@ -18,6 +18,21 @@ class AristaBaseCommandProcessor(BaseCommandProcessor):
     def __init__(self, display_class):
         self.display = display_class(self)
 
+    def read_vlan_number(self, input):
+        try:
+            number = int(input)
+        except ValueError:
+            self.display.invalid_command("Invalid input")
+            return None
+
+        if number < 0 or number > 4094:
+            self.display.invalid_command("Invalid input")
+        elif number == 0:
+            self.display.invalid_command("Incomplete command")
+        else:
+            return number
+
+        return None
 
 def vlan_name(vlan):
     return vlan.name or ("default" if vlan.number == 1 else None)

--- a/fake_switches/arista/command_processor/__init__.py
+++ b/fake_switches/arista/command_processor/__init__.py
@@ -1,3 +1,23 @@
+# Copyright 2018 Inap.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from fake_switches.command_processing.base_command_processor import BaseCommandProcessor
+
+
+class AristaBaseCommandProcessor(BaseCommandProcessor):
+    def __init__(self, display_class):
+        self.display = display_class(self)
+
 
 def vlan_name(vlan):
     return vlan.name or ("default" if vlan.number == 1 else None)

--- a/fake_switches/arista/command_processor/config.py
+++ b/fake_switches/arista/command_processor/config.py
@@ -25,17 +25,9 @@ class ConfigCommandProcessor(AristaBaseCommandProcessor):
         return self.switch_configuration.name + "(config)#"
 
     def do_vlan(self, raw_number, *_):
-        try:
-            number = int(raw_number)
-        except ValueError:
-            self.display.error("Invalid input")
-            return
+        number = self.read_vlan_number(raw_number)
 
-        if number < 0 or number > 4094:
-            self.display.error("Invalid input")
-        elif number == 0:
-            self.display.error("Incomplete command")
-        else:
+        if number is not None:
             vlan = self.switch_configuration.get_vlan(number)
             if not vlan:
                 vlan = self.switch_configuration.new("Vlan", number)

--- a/fake_switches/arista/command_processor/config.py
+++ b/fake_switches/arista/command_processor/config.py
@@ -11,15 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from fake_switches.arista.command_processor import AristaBaseCommandProcessor
 
-from fake_switches.command_processing.base_command_processor import BaseCommandProcessor
 
-
-class ConfigCommandProcessor(BaseCommandProcessor):
+class ConfigCommandProcessor(AristaBaseCommandProcessor):
     interface_separator = ""
 
-    def __init__(self, config_vlan):
-        super(ConfigCommandProcessor, self).__init__()
+    def __init__(self, display_class, config_vlan):
+        super(ConfigCommandProcessor, self).__init__(display_class)
         self.config_vlan_processor = config_vlan
 
     def get_prompt(self):
@@ -29,13 +28,13 @@ class ConfigCommandProcessor(BaseCommandProcessor):
         try:
             number = int(raw_number)
         except ValueError:
-            self.write_line("% Invalid input")
+            self.display.error("Invalid input")
             return
 
         if number < 0 or number > 4094:
-            self.write_line("% Invalid input")
+            self.display.error("Invalid input")
         elif number == 0:
-            self.write_line("% Incomplete command")
+            self.display.error("Incomplete command")
         else:
             vlan = self.switch_configuration.get_vlan(number)
             if not vlan:

--- a/fake_switches/arista/command_processor/config_vlan.py
+++ b/fake_switches/arista/command_processor/config_vlan.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from fake_switches.arista.command_processor import AristaBaseCommandProcessor
 
-from fake_switches.command_processing.base_command_processor import BaseCommandProcessor
 
-
-class ConfigVlanCommandProcessor(BaseCommandProcessor):
+class ConfigVlanCommandProcessor(AristaBaseCommandProcessor):
     def init(self, switch_configuration, terminal_controller, logger, piping_processor, *args):
-        super(ConfigVlanCommandProcessor, self).init(switch_configuration, terminal_controller, logger, piping_processor)
+        super(ConfigVlanCommandProcessor, self).init(switch_configuration, terminal_controller, logger,
+                                                     piping_processor)
         self.vlan = args[0]
 
     def get_prompt(self):

--- a/fake_switches/arista/command_processor/default.py
+++ b/fake_switches/arista/command_processor/default.py
@@ -32,9 +32,14 @@ class DefaultCommandProcessor(AristaBaseCommandProcessor):
     def do_show(self, *args):
         if "vlan".startswith(args[0]):
             if len(args) == 2:
-                vlans = list(filter(lambda e: e.number == int(args[1]), self.switch_configuration.vlans))
+                number = self.read_vlan_number(args[1])
+                if number is None:
+                    return
+
+                vlans = list(filter(lambda e: e.number == number, self.switch_configuration.vlans))
                 if len(vlans) == 0:
-                    self.display.error("VLAN {} not found in current VLAN database".format(args[1]))
+                    self.display.invalid_result("VLAN {} not found in current VLAN database".format(args[1]),
+                                                json_data=_to_vlans_json([]))
                     return
             else:
                 vlans = self.switch_configuration.vlans

--- a/fake_switches/arista/command_processor/default.py
+++ b/fake_switches/arista/command_processor/default.py
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from fake_switches.arista.command_processor import vlan_display_name
-from fake_switches.command_processing.base_command_processor import BaseCommandProcessor
+from fake_switches.arista.command_processor import vlan_display_name, AristaBaseCommandProcessor
 from fake_switches.command_processing.shell_session import TerminalExitSignal
 
 
-class DefaultCommandProcessor(BaseCommandProcessor):
-    def __init__(self, enabled):
-        super(DefaultCommandProcessor, self).__init__()
+class DefaultCommandProcessor(AristaBaseCommandProcessor):
+    def __init__(self, display_class, enabled):
+        super(DefaultCommandProcessor, self).__init__(display_class)
         self.enabled_processor = enabled
 
     def get_prompt(self):
@@ -35,13 +34,22 @@ class DefaultCommandProcessor(BaseCommandProcessor):
             if len(args) == 2:
                 vlans = list(filter(lambda e: e.number == int(args[1]), self.switch_configuration.vlans))
                 if len(vlans) == 0:
-                    self.write_line("% VLAN {} not found in current VLAN database".format(args[1]))
+                    self.display.error("VLAN {} not found in current VLAN database".format(args[1]))
                     return
             else:
                 vlans = self.switch_configuration.vlans
 
-            self.write_line("VLAN  Name                             Status    Ports")
-            self.write_line("----- -------------------------------- --------- -------------------------------")
-            for vlan in sorted(vlans, key=lambda v: v.number):
-                self.write_line("{: <5} {: <32} active".format(vlan.number, vlan_display_name(vlan)))
-            self.write_line("")
+            self.display.show_vlans(_to_vlans_json(vlans))
+
+
+def _to_vlans_json(vlans):
+    return {
+        "vlans": {
+            str(vlan.number): {
+                "dynamic": False,
+                "interfaces": {},
+                "name": vlan_display_name(vlan),
+                "status": "active"
+            } for vlan in vlans
+        }
+    }

--- a/fake_switches/arista/command_processor/enabled.py
+++ b/fake_switches/arista/command_processor/enabled.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from fake_switches.arista.command_processor import vlan_display_name
+from fake_switches.arista.command_processor.default import DefaultCommandProcessor
 
-from fake_switches.command_processing.base_command_processor import BaseCommandProcessor
 
-
-class EnabledCommandProcessor(BaseCommandProcessor):
+class EnabledCommandProcessor(DefaultCommandProcessor):
     def __init__(self, config):
-        super(EnabledCommandProcessor, self).__init__()
+        super(EnabledCommandProcessor, self).__init__(enabled=None)
         self.config_processor = config
 
     def get_prompt(self):
@@ -30,25 +30,10 @@ class EnabledCommandProcessor(BaseCommandProcessor):
         self.move_to(self.config_processor)
 
     def do_show(self, *args):
-        if "vlan".startswith(args[0]):
-            if len(args) == 2:
-                vlans = list(filter(lambda e: e.number == int(args[1]), self.switch_configuration.vlans))
-                if len(vlans) == 0:
-                    self.write_line("% VLAN {} not found in current VLAN database".format(args[1]))
-                    return
-            else:
-                vlans = self.switch_configuration.vlans
-
-            self.write_line("VLAN  Name                             Status    Ports")
-            self.write_line("----- -------------------------------- --------- -------------------------------")
-            for vlan in sorted(vlans, key=lambda v: v.number):
-                self.write_line("{: <5} {: <32} active".format(vlan.number, vlan_display_name(vlan)))
-            self.write_line("")
-        elif "running-config".startswith(args[0]):
+        if "running-config".startswith(args[0]):
             self._show_running_config()
-
-    def do_exit(self):
-        self.is_done = True
+        else:
+            super(EnabledCommandProcessor, self).do_show(*args)
 
     def do_terminal(self, *_):
         self.write("Pagination disabled.")
@@ -72,11 +57,3 @@ class EnabledCommandProcessor(BaseCommandProcessor):
             self.write_line("   mac address learning")
             self.write_line("   state active")
             self.write_line("!")
-
-
-def vlan_name(vlan):
-    return vlan.name or ("default" if vlan.number == 1 else None)
-
-
-def vlan_display_name(vlan):
-    return vlan_name(vlan) or "VLAN{:04d}".format(vlan.number)

--- a/fake_switches/arista/command_processor/enabled.py
+++ b/fake_switches/arista/command_processor/enabled.py
@@ -16,8 +16,8 @@ from fake_switches.arista.command_processor.default import DefaultCommandProcess
 
 
 class EnabledCommandProcessor(DefaultCommandProcessor):
-    def __init__(self, config):
-        super(EnabledCommandProcessor, self).__init__(enabled=None)
+    def __init__(self, display_class, config):
+        super(EnabledCommandProcessor, self).__init__(display_class, enabled=None)
         self.config_processor = config
 
     def get_prompt(self):

--- a/fake_switches/arista/command_processor/enabled.py
+++ b/fake_switches/arista/command_processor/enabled.py
@@ -44,12 +44,34 @@ class EnabledCommandProcessor(BaseCommandProcessor):
             for vlan in sorted(vlans, key=lambda v: v.number):
                 self.write_line("{: <5} {: <32} active".format(vlan.number, vlan_display_name(vlan)))
             self.write_line("")
+        elif "running-config".startswith(args[0]):
+            self._show_running_config()
 
     def do_exit(self):
         self.is_done = True
 
     def do_terminal(self, *_):
         self.write("Pagination disabled.")
+
+    def _show_running_config(self):
+        self._show_header()
+        self._show_vlans(sorted(self.switch_configuration.vlans, key=lambda v: v.number))
+        self.write_line("end")
+
+    def _show_header(self):
+        self.write_line("! Command: show running-config all")
+        self.write_line("! device: {} (vEOS, EOS-4.20.8M)".format(self.switch_configuration.name))
+        self.write_line("!")
+        self.write_line("! boot system flash:/vEOS-lab.swi")
+        self.write_line("!")
+
+    def _show_vlans(self, vlans):
+        for vlan in vlans:
+            self.write_line("vlan {}".format(vlan.number))
+            self.write_line("   name {}".format(vlan_display_name(vlan)))
+            self.write_line("   mac address learning")
+            self.write_line("   state active")
+            self.write_line("!")
 
 
 def vlan_name(vlan):

--- a/fake_switches/arista/command_processor/terminal_display.py
+++ b/fake_switches/arista/command_processor/terminal_display.py
@@ -1,0 +1,31 @@
+# Copyright 2018 Inap.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class TerminalDisplay(object):
+    def __init__(self, processor):
+        self.processor = processor
+
+    def error(self, message):
+        self.processor.write_line("% {}".format(message))
+
+    def show_vlans(self, vlans_json):
+        self.processor.write_line("VLAN  Name                             Status    Ports")
+        self.processor.write_line("----- -------------------------------- --------- -------------------------------")
+
+        for vlan_number in sorted(vlans_json["vlans"].keys(), key=lambda e: int(e)):
+            self.processor.write_line("{: <5} {: <32} active"
+                                      .format(vlan_number, vlans_json["vlans"][vlan_number]["name"]))
+
+        self.processor.write_line("")

--- a/fake_switches/arista/command_processor/terminal_display.py
+++ b/fake_switches/arista/command_processor/terminal_display.py
@@ -17,7 +17,13 @@ class TerminalDisplay(object):
     def __init__(self, processor):
         self.processor = processor
 
-    def error(self, message):
+    def invalid_command(self, message, json_data=None):
+        self._error(message)
+
+    def invalid_result(self, message, json_data=None):
+        self._error(message)
+
+    def _error(self, message):
         self.processor.write_line("% {}".format(message))
 
     def show_vlans(self, vlans_json):

--- a/fake_switches/arista/eapi.py
+++ b/fake_switches/arista/eapi.py
@@ -1,0 +1,76 @@
+# Copyright 2018 Inap.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+from twisted.web import resource
+
+from fake_switches.command_processing.piping_processor_base import NotPipingProcessor
+from fake_switches.terminal import TerminalController
+
+
+class EAPI(resource.Resource, object):
+    isLeaf = True
+
+    def __init__(self, switch_configuration, command_processor, logger):
+        super(EAPI, self).__init__()
+
+        self.switch_configuration = switch_configuration
+        self.command_processor = command_processor
+        self.logger = logger
+
+    def render_POST(self, request):
+        content = json.loads(request.content.read().decode())
+        self.logger.info("Request in: {}".format(content))
+
+        buffer = BufferingTerminalController()
+        self.command_processor.init(
+            switch_configuration=self.switch_configuration,
+            terminal_controller=buffer,
+            logger=self.logger,
+            piping_processor=NotPipingProcessor()
+        )
+
+        result = {
+            "jsonrpc": content["jsonrpc"],
+            "id": content["id"],
+            "result": []
+        }
+
+        for cmd in content["params"]["cmds"]:
+            self.command_processor.process_command(cmd)
+            result["result"].append({
+                "output": strip_prompt(self.command_processor, buffer.pop())
+            })
+
+        return json.dumps(result).encode()
+
+
+def strip_prompt(command_processor, content):
+    prompt = command_processor.get_prompt()
+    return content[:-len(prompt)]
+
+
+class BufferingTerminalController(TerminalController):
+
+    def __init__(self):
+        self.buffer = ""
+
+    def pop(self):
+        buffer = self.buffer
+        self.buffer = ""
+        return buffer
+
+    def write(self, text):
+        self.buffer += text

--- a/fake_switches/command_processing/shell_session.py
+++ b/fake_switches/command_processing/shell_session.py
@@ -1,4 +1,4 @@
-# Copyright 2015 Internap.
+# Copyright 2018 Inap.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-
 class ShellSession(object):
     def __init__(self, command_processor):
         self.command_processor = command_processor
@@ -22,7 +21,12 @@ class ShellSession(object):
 
     def receive(self, line):
         self.command_processor.logger.debug("received: %s" % line)
-        if not self.command_processor.process_command(line):
+        try:
+            processed = self.command_processor.process_command(line)
+        except TerminalExitSignal:
+            return False
+
+        if not processed:
             self.command_processor.logger.info("Command not supported : %s" % line)
 
             self.handle_unknown_command(line)
@@ -34,3 +38,6 @@ class ShellSession(object):
     def handle_unknown_command(self, line):
         pass
 
+
+class TerminalExitSignal(Exception):
+    pass

--- a/fake_switches/transports/http_service.py
+++ b/fake_switches/transports/http_service.py
@@ -12,20 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 
-class SwitchCore(object):
-    def __init__(self, switch_configuration):
-        self.switch_configuration = switch_configuration
+from twisted.web.server import Site
 
-    def launch(self, protocol, terminal_controller):
-        raise NotImplementedError()
+from fake_switches.transports.base_transport import BaseTransport
 
-    @staticmethod
-    def get_default_ports():
-        raise NotImplementedError()
 
-    def get_netconf_protocol(self):
-        raise NotImplementedError()
+class SwitchHttpService(BaseTransport):
+    def hook_to_reactor(self, reactor):
+        site = Site(self.switch_core.get_http_resource())
 
-    def get_http_resource(self):
-        raise NotImplementedError()
+        lport = reactor.listenTCP(port=self.port, factory=site, interface=self.ip)
+        logging.info(lport)
+        logging.info("{} (HTTP): Registered on {} tcp/{}"
+                     .format(self.switch_core.switch_configuration.name, self.ip, self.port))

--- a/test-constraints.txt
+++ b/test-constraints.txt
@@ -11,25 +11,23 @@ bcrypt==3.1.4             # via paramiko
 cffi==1.11.5
 constantly==15.1.0
 cryptography==2.3.1
-enum34==1.1.6
 flexmock==0.10.2
-funcsigs==1.0.2           # via mock
 idna==2.7
 incremental==17.5.0
-ipaddress==1.0.22
-lxml==4.2.4
+lxml==4.2.5
 mock==2.0.0
-ncclient==0.6.2
+ncclient==0.6.3
 netaddr==0.7.19
 nose==1.3.7
-paramiko==2.4.1           # via ncclient
-pbr==4.2.0                # via mock
+paramiko==2.4.2           # via ncclient
+pbr==4.3.0                # via mock
 pexpect==4.6.0
 ptyprocess==0.6.0         # via pexpect
 pyasn1==0.4.4
-pycparser==2.18
+pycparser==2.19
+pyeapi==0.8.2
 pyhamcrest==1.9.0
-pynacl==1.2.1             # via paramiko
+pynacl==1.3.0             # via paramiko
 selectors2==2.0.1         # via ncclient
 six==1.11.0
 twisted[conch]==16.6.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,4 @@ pyhamcrest>=1.6
 pexpect>=4.2.1
 flexmock>=0.9.7
 ncclient>=0.5.2
+pyeapi

--- a/tests/arista/test_arista_rest_api.py
+++ b/tests/arista/test_arista_rest_api.py
@@ -1,0 +1,36 @@
+# Copyright 2018 Inap.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+import pyeapi
+from hamcrest import assert_that, is_
+
+from tests.util.global_reactor import TEST_SWITCHES
+
+
+class TestAristaRestApi(unittest.TestCase):
+    def test_get_vlan(self):
+
+        conf = TEST_SWITCHES["arista"]
+        node = pyeapi.connect(transport="http", host="127.0.0.1", port=conf["http"],
+                              username="root", password="root", return_node=True)
+
+        result = node.api('vlans').get(1)
+
+        assert_that(result, is_({
+            "name": "default",
+            "state": "active",
+            "trunk_groups": [],
+            "vlan_id": 1
+        }))

--- a/tests/arista/test_arista_rest_api.py
+++ b/tests/arista/test_arista_rest_api.py
@@ -15,6 +15,7 @@ import unittest
 
 import pyeapi
 from hamcrest import assert_that, is_
+from pyeapi.eapilib import CommandError
 
 from tests.util.global_reactor import TEST_SWITCHES
 
@@ -58,6 +59,32 @@ class TestAristaRestApi(unittest.TestCase):
                 }
             ]
         }))
+
+    def test_execute_show_vlan_unknown_vlan(self):
+        with self.assertRaises(CommandError) as expect:
+            self.connection.execute("show vlan 999")
+
+        assert_that(str(expect.exception), is_(
+            "Error [1000]: CLI command 1 of 1 'show vlan 999' failed: could not run command "
+            "[VLAN 999 not found in current VLAN database]"
+        ))
+
+        assert_that(expect.exception.output, is_([
+            {
+                'vlans': {},
+                'sourceDetail': '',
+                'errors': ['VLAN 999 not found in current VLAN database']
+            }
+        ]))
+
+    def test_execute_show_vlan_invalid_input(self):
+        with self.assertRaises(CommandError) as expect:
+            self.connection.execute("show vlan shizzle")
+
+        assert_that(str(expect.exception), is_(
+            "Error [1002]: CLI command 1 of 1 'show vlan shizzle' failed: invalid command "
+            "[Invalid input]"
+        ))
 
 
 class AnyId(object):

--- a/tests/arista/test_arista_running_config.py
+++ b/tests/arista/test_arista_running_config.py
@@ -1,0 +1,39 @@
+# Copyright 2018 Inap.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from tests.arista import enable
+from tests.util.protocol_util import with_protocol, ProtocolTest, SshTester
+
+
+class TestAristaRunningConfig(ProtocolTest):
+    tester_class = SshTester
+    test_switch = "arista"
+
+    @with_protocol
+    def test_running_config_all(self, t):
+        enable(t)
+
+        t.write("show running-config all")
+        t.readln("! Command: show running-config all")
+        t.readln("! device: my_arista (vEOS, EOS-4.20.8M)")
+        t.readln("!")
+        t.readln("! boot system flash:/vEOS-lab.swi")
+        t.readln("!")
+        t.readln("vlan 1")
+        t.readln("   name default")
+        t.readln("   mac address learning")
+        t.readln("   state active")
+        t.readln("!")
+        t.readln("end")
+        t.read("my_arista#")

--- a/tests/arista/test_arista_switch_protocol.py
+++ b/tests/arista/test_arista_switch_protocol.py
@@ -125,6 +125,15 @@ class TestAristaSwitchProtocol(ProtocolTest):
         remove_vlan(t, "2222")
         remove_vlan(t, "3333")
 
+    @with_protocol
+    def test_show_vlan_without_enable(self, t):
+        t.write("show vlan")
+        t.readln("VLAN  Name                             Status    Ports")
+        t.readln("----- -------------------------------- --------- -------------------------------")
+        t.readln("1     default                          active")
+        t.readln("")
+        t.read("my_arista>")
+
 
 class TestAristaSwitchProtocolSSH(TestAristaSwitchProtocol):
     __test__ = True

--- a/tests/util/global_reactor.py
+++ b/tests/util/global_reactor.py
@@ -15,6 +15,7 @@
 import threading
 
 from fake_switches.switch_factory import SwitchFactory
+from fake_switches.transports.http_service import SwitchHttpService
 from fake_switches.transports.ssh_service import SwitchSshService
 from fake_switches.transports.telnet_service import SwitchTelnetService
 from tests.util import _juniper_ports_with_less_ae, _unique_port
@@ -26,6 +27,7 @@ TEST_SWITCHES = {
         "model": "arista_generic",
         "hostname": "my_arista",
         "ssh": _unique_port(),
+        "http": _unique_port(),
         "extra": {},
     },
     "brocade": {
@@ -168,6 +170,12 @@ class ThreadedReactor(threading.Thread):
                                  switch_core=switch_core,
                                  users={'root': b'root'}
                                  ).hook_to_reactor(cls._threaded_reactor.reactor)
+            if "http" in conf:
+                SwitchHttpService("127.0.0.1",
+                                  port=conf["http"],
+                                  switch_core=switch_core,
+                                  users={'root': b'root'}
+                                  ).hook_to_reactor(cls._threaded_reactor.reactor)
 
             cls._threaded_reactor.switches[name] = switch_core
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,11 +14,11 @@ install_command =
     pip install -c {toxinidir}/test-constraints.txt {opts} {packages}
 
 [testenv:bump-dependencies]
+basepython = python3
 skipsdist = True
 skip_install = true
 install_command = pip install {opts} {packages}
--deps = pip-tools==2.0.2
+deps = pip-tools==2.0.2
 commands =
     pip-compile --upgrade --no-index --no-emit-trusted-host --output-file constraints.txt requirements.txt
     pip-compile --upgrade --no-index --no-emit-trusted-host --output-file test-constraints.txt test-requirements.txt constraints.txt
-


### PR DESCRIPTION
The errors can now display partial result which are currently ignored
by the terminal display.

The show vlan and config vlan share the same validation routine so it
was pushed to the common parent.