### PR TITLE
Support empty reponses

### DIFF
--- a/fake_switches/arista/eapi.py
+++ b/fake_switches/arista/eapi.py
@@ -122,7 +122,7 @@ class JsonDriver(object):
     display_class = JsonDisplay
 
     def format_output(self, command_processor):
-        obj = command_processor.display.display_object
+        obj = command_processor.display.display_object or {}
         obj['sourceDetail'] = ''
         return obj
 

--- a/tests/arista/test_arista_rest_api.py
+++ b/tests/arista/test_arista_rest_api.py
@@ -15,6 +15,7 @@ import unittest
 
 import pyeapi
 from hamcrest import assert_that, is_
+from pyeapi.api.vlans import Vlans
 from pyeapi.eapilib import CommandError
 
 from tests.util.global_reactor import TEST_SWITCHES
@@ -85,6 +86,13 @@ class TestAristaRestApi(unittest.TestCase):
             "Error [1002]: CLI command 1 of 1 'show vlan shizzle' failed: invalid command "
             "[Invalid input]"
         ))
+
+    def test_add_and_remove_vlan(self):
+        result = Vlans(self.node).configure_vlan("737", ["name wwaaat!"])
+        assert_that(result, is_(True))
+
+        result = Vlans(self.node).delete("737")
+        assert_that(result, is_(True))
 
 
 class AnyId(object):


### PR DESCRIPTION
A command with an empty response should return an empty json object