### PR TITLE
Add default ports for transports services

### DIFF
--- a/fake_switches/transports/__init__.py
+++ b/fake_switches/transports/__init__.py
@@ -1,4 +1,5 @@
 from fake_switches.transports.ssh_service import SwitchSshService
 from fake_switches.transports.telnet_service import SwitchTelnetService
+from fake_switches.transports.http_service import SwitchHttpService
 
-__all__ = ['SwitchTelnetService', 'SwitchSshService']
+__all__ = ['SwitchTelnetService', 'SwitchSshService', 'SwitchHttpService']

--- a/fake_switches/transports/http_service.py
+++ b/fake_switches/transports/http_service.py
@@ -20,6 +20,9 @@ from fake_switches.transports.base_transport import BaseTransport
 
 
 class SwitchHttpService(BaseTransport):
+    def __init__(self, ip=None, port=80, switch_core=None, users=None):
+        super(SwitchHttpService, self).__init__(ip, port, switch_core, users)
+
     def hook_to_reactor(self, reactor):
         site = Site(self.switch_core.get_http_resource())
 

--- a/fake_switches/transports/ssh_service.py
+++ b/fake_switches/transports/ssh_service.py
@@ -103,6 +103,9 @@ Jk9Gg4yPCL/ZKyIEQzqtkBUyK2P5x1OP32tcC9CxHZlXJLJdhtuQTw==
 
 
 class SwitchSshService(BaseTransport):
+    def __init__(self, ip=None, port=22, switch_core=None, users=None):
+        super(SwitchSshService, self).__init__(ip, port, switch_core, users)
+
     def hook_to_reactor(self, reactor):
         ssh_factory = factory.SSHFactory()
         ssh_factory.portal = portal.Portal(SSHDemoRealm(self.switch_core))

--- a/fake_switches/transports/telnet_service.py
+++ b/fake_switches/transports/telnet_service.py
@@ -29,6 +29,9 @@ class SwitchTelnetFactory(Factory):
 
 
 class SwitchTelnetService(BaseTransport):
+    def __init__(self, ip=None, port=23, switch_core=None, users=None):
+        super(SwitchTelnetService, self).__init__(ip, port, switch_core, users)
+
     def hook_to_reactor(self, reactor):
         factory = SwitchTelnetFactory(self.switch_core)
         port = reactor.listenTCP(port=self.port, factory=factory, interface=self.ip)

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -1,0 +1,22 @@
+import unittest
+
+from hamcrest import assert_that, equal_to
+
+from fake_switches.transports import SwitchSshService, SwitchTelnetService, SwitchHttpService
+
+
+class TransportsTests(unittest.TestCase):
+    def test_http_service_has_default_port(self):
+        http_service = SwitchHttpService()
+
+        assert_that(http_service.port, equal_to(80))
+
+    def test_ssh_service_has_default_port(self):
+        ssh_service = SwitchSshService()
+
+        assert_that(ssh_service.port, equal_to(22))
+
+    def test_telnet_service_has_default_port(self):
+        telnet_service = SwitchTelnetService()
+
+        assert_that(telnet_service.port, equal_to(23))


### PR DESCRIPTION
This will increase the compatibility between transports services and
deprecated ssh_service and telnet_service.

80 for HTTP
22 for SSH
23 for Telnet