### PR TITLE
Use a unique display object

### DIFF
--- a/fake_switches/arista/arista_core.py
+++ b/fake_switches/arista/arista_core.py
@@ -43,7 +43,7 @@ class AristaSwitchCore(SwitchCore):
         self.logger = logging.getLogger("fake_switches.arista.{}.{}.{}"
                                         .format(self.switch_configuration.name, self.last_connection_id, protocol))
 
-        processor = self.processor_stack(display_class=TerminalDisplay)
+        processor = self.processor_stack(display=TerminalDisplay())
 
         processor.init(self.switch_configuration,
                        LoggingTerminalController(self.logger, terminal_controller),
@@ -56,8 +56,8 @@ class AristaSwitchCore(SwitchCore):
     def get_default_ports():
         return []
 
-    def processor_stack(self, display_class):
-        common = (display_class,)
+    def processor_stack(self, display):
+        common = (display,)
 
         return DefaultCommandProcessor(
             *common, enabled=EnabledCommandProcessor(

--- a/fake_switches/arista/command_processor/__init__.py
+++ b/fake_switches/arista/command_processor/__init__.py
@@ -15,20 +15,20 @@ from fake_switches.command_processing.base_command_processor import BaseCommandP
 
 
 class AristaBaseCommandProcessor(BaseCommandProcessor):
-    def __init__(self, display_class):
-        self.display = display_class(self)
+    def __init__(self, display):
+        self.display = display
 
     def read_vlan_number(self, input):
         try:
             number = int(input)
         except ValueError:
-            self.display.invalid_command("Invalid input")
+            self.display.invalid_command(self, "Invalid input")
             return None
 
         if number < 0 or number > 4094:
-            self.display.invalid_command("Invalid input")
+            self.display.invalid_command(self, "Invalid input")
         elif number == 0:
-            self.display.invalid_command("Incomplete command")
+            self.display.invalid_command(self, "Incomplete command")
         else:
             return number
 

--- a/fake_switches/arista/command_processor/default.py
+++ b/fake_switches/arista/command_processor/default.py
@@ -38,13 +38,13 @@ class DefaultCommandProcessor(AristaBaseCommandProcessor):
 
                 vlans = list(filter(lambda e: e.number == number, self.switch_configuration.vlans))
                 if len(vlans) == 0:
-                    self.display.invalid_result("VLAN {} not found in current VLAN database".format(args[1]),
+                    self.display.invalid_result(self, "VLAN {} not found in current VLAN database".format(args[1]),
                                                 json_data=_to_vlans_json([]))
                     return
             else:
                 vlans = self.switch_configuration.vlans
 
-            self.display.show_vlans(_to_vlans_json(vlans))
+            self.display.show_vlans(self, _to_vlans_json(vlans))
 
 
 def _to_vlans_json(vlans):

--- a/fake_switches/arista/command_processor/terminal_display.py
+++ b/fake_switches/arista/command_processor/terminal_display.py
@@ -14,24 +14,21 @@
 
 
 class TerminalDisplay(object):
-    def __init__(self, processor):
-        self.processor = processor
+    def invalid_command(self, processor, message, json_data=None):
+        self._error(processor, message)
 
-    def invalid_command(self, message, json_data=None):
-        self._error(message)
+    def invalid_result(self, processor, message, json_data=None):
+        self._error(processor, message)
 
-    def invalid_result(self, message, json_data=None):
-        self._error(message)
+    def _error(self, processor, message):
+        processor.write_line("% {}".format(message))
 
-    def _error(self, message):
-        self.processor.write_line("% {}".format(message))
-
-    def show_vlans(self, vlans_json):
-        self.processor.write_line("VLAN  Name                             Status    Ports")
-        self.processor.write_line("----- -------------------------------- --------- -------------------------------")
+    def show_vlans(self, processor, vlans_json):
+        processor.write_line("VLAN  Name                             Status    Ports")
+        processor.write_line("----- -------------------------------- --------- -------------------------------")
 
         for vlan_number in sorted(vlans_json["vlans"].keys(), key=lambda e: int(e)):
-            self.processor.write_line("{: <5} {: <32} active"
+            processor.write_line("{: <5} {: <32} active"
                                       .format(vlan_number, vlans_json["vlans"][vlan_number]["name"]))
 
-        self.processor.write_line("")
+        processor.write_line("")

--- a/fake_switches/arista/eapi.py
+++ b/fake_switches/arista/eapi.py
@@ -37,7 +37,7 @@ class EAPI(resource.Resource, object):
 
         driver = driver_for(content["params"]["format"])
 
-        command_processor = self.processor_stack_factory(display_class=driver.display_class)
+        command_processor = self.processor_stack_factory(display=driver.display_class())
         command_processor.init(
             switch_configuration=self.switch_configuration,
             terminal_controller=BufferingTerminalController(),
@@ -105,14 +105,14 @@ class JsonDisplay(object):
     def __init__(self, *_):
         self.display_object = None
 
-    def invalid_command(self, message, json_data=None):
+    def invalid_command(self, processor, message, json_data=None):
         raise InvalidCommand(message, json_data=json_data)
 
-    def invalid_result(self, message, json_data=None):
+    def invalid_result(self, processor, message, json_data=None):
         raise InvalidResult(message, json_data=json_data)
 
     def __getattr__(self, item):
-        def collector(obj):
+        def collector(processor, obj):
             self.display_object = obj
 
         return collector


### PR DESCRIPTION
Having one for each processor was indeed simplifying how to pass the
output channel (the processor itself) on instantiation but it causes a
problem in the EAPI since that service holds a reference to the base
processor only and the base processor is the one dispatching down its
tree so it's hard to know which processor processed the command to get
that processor's display to get the output object.

Having a unique display and passing the output channel on each call will
solve this as we don't care who processed it.

We cannot simply pass the terminal controller to the display since there
is a piping mechanism in the .write that would need to be copied. A
refactor could turn that into a mixin, or the terminal controller could
controller the piping.