### PR TITLE
Add mpls ip support on interface vlan

### DIFF
--- a/fake_switches/arista/command_processor/config_interface.py
+++ b/fake_switches/arista/command_processor/config_interface.py
@@ -65,6 +65,18 @@ class ConfigInterfaceCommandProcessor(AristaBaseCommandProcessor):
     def do_no_load_interval(self):
         self.port.load_interval = None
 
+    def do_mpls(self, *args):
+        if args[0] == 'ip':
+            self.port.mpls_ip = True
+        else:
+            raise NotImplementedError
+
+    def do_no_mpls(self, *args):
+        if args[0] == 'ip':
+            self.port.mpls_ip = False
+        else:
+            raise NotImplementedError
+
     def do_switchport(self, *args):
         operations = [
             (("mode",), self._switchport_mode),

--- a/fake_switches/arista/command_processor/enabled.py
+++ b/fake_switches/arista/command_processor/enabled.py
@@ -83,6 +83,8 @@ class EnabledCommandProcessor(DefaultCommandProcessor):
                     self.write_line("   ip address {}".format(ip))
                 for ip in port.ips[1:]:
                     self.write_line("   ip address {} secondary".format(ip))
+                if port.mpls_ip is False:
+                    self.write_line("   no mpls ip")
                 for ip_helper in port.ip_helpers:
                     self.write_line("   ip helper-address {}".format(ip_helper))
                 for varp_address in sorted(port.varp_addresses):

--- a/fake_switches/switch_configuration.py
+++ b/fake_switches/switch_configuration.py
@@ -217,6 +217,7 @@ class VlanPort(Port):
         self.ip_proxy_arp = True
         self.unicast_reverse_path_forwarding = False
         self.load_interval = None
+        self.mpls_ip = True
 
     def get_vrrp_group(self, group):
         return next((vrrp for vrrp in self.vrrps if vrrp.group_id == group), None)

--- a/tests/arista/test_arista_mpls_ip.py
+++ b/tests/arista/test_arista_mpls_ip.py
@@ -1,0 +1,102 @@
+# Copyright 2019 Internap.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from hamcrest import assert_that, is_
+
+from tests.arista import enable, create_vlan, create_interface_vlan, configuring_interface_vlan, \
+    assert_interface_configuration, with_eapi, remove_interface_vlan, remove_vlan
+from tests.util.protocol_util import ProtocolTest, SshTester, with_protocol
+
+
+class TestAristaMplsIp(ProtocolTest):
+    tester_class = SshTester
+    test_switch = "arista"
+
+    def setUp(self):
+        self.vlan = "299"
+        super(TestAristaMplsIp, self).setUp()
+        self._prepare_vlan()
+
+    def tearDown(self):
+        self.cleanup_vlan()
+        super(TestAristaMplsIp, self).tearDown()
+
+    @with_protocol
+    def _prepare_vlan(self, t):
+        enable(t)
+        create_vlan(t, self.vlan)
+        create_interface_vlan(t, self.vlan)
+
+    @with_protocol
+    def cleanup_vlan(self, t):
+        enable(t)
+        remove_interface_vlan(t, self.vlan)
+        remove_vlan(t, self.vlan)
+
+    @with_protocol
+    def test_interface_with_no_mpls_ip(self, t):
+        enable(t)
+
+        configuring_interface_vlan(t, "299", do="no mpls ip")
+
+        assert_interface_configuration(t, "Vlan299", [
+            "interface Vlan299",
+            "   no mpls ip"
+        ])
+
+    @with_protocol
+    @with_eapi
+    def test_running_config_with_no_mpls_ip_via_api(self, t, api):
+        enable(t)
+
+        configuring_interface_vlan(t, "299", do="no mpls ip")
+
+        result = api.enable("show running-config interfaces Vlan299", strict=True, encoding="text")
+
+        assert_that(result, is_([
+            {
+                "command": "show running-config interfaces Vlan299",
+                "encoding": "text",
+                "response": {
+                    "output": "interface Vlan299\n   no mpls ip\n"
+                },
+                "result": {
+                    "output": "interface Vlan299\n   no mpls ip\n"
+                }
+            }
+        ]))
+
+    @with_protocol
+    def test_mpls_ip(self, t):
+        enable(t)
+
+        configuring_interface_vlan(t, "299", do="mpls ip")
+
+        assert_interface_configuration(t, "Vlan299", [
+            "interface Vlan299"
+        ])
+
+    @with_protocol
+    def test_no_mpls_raise_error_with_unsupported_command(self, t):
+        enable(t)
+
+        t.write("no mpls ldp")
+        t.readln("% Invalid input")
+
+    @with_protocol
+    def test_mpls_raise_error_with_unsupported_command(self, t):
+        enable(t)
+
+        t.write("mpls ldp")
+        t.readln("% Invalid input")


### PR DESCRIPTION
MPLS is a networking process that replaces complete network addresses with
short path labels for directing data packets to network nodes.