### PR TITLE
Fix invalid private key error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 COPY requirements.txt /usr/src/app/
+RUN pip install cryptography==3.0
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . /usr/src/app


### PR DESCRIPTION
Simple fix for the time being, until the repo gets revamped for Python3. 
Only added the requirement for `crytopgraphy` to version 3.0 since this prevents the existing error "invalid private key" that occurs when running the docker image. This should also fix any other issues with running fake-switches with python2 for now. 

